### PR TITLE
[feat/29] user base info api

### DIFF
--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/ROLE.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/ROLE.java
@@ -1,4 +1,4 @@
-package toy.bookchat.bookchat.domain.user.domain;
+package toy.bookchat.bookchat.domain.user;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +12,7 @@ public enum ROLE implements GrantedAuthority {
 
 
     private final String roleName;
+
     @Override
     public String getAuthority() {
         return ROLE.USER.toString();

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/User.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/User.java
@@ -1,13 +1,15 @@
 package toy.bookchat.bookchat.domain.user;
 
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import toy.bookchat.bookchat.domain.user.domain.ROLE;
 import toy.bookchat.bookchat.security.oauth.OAuth2Provider;
-
-import javax.persistence.*;
 
 @Entity
 @Getter

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/api/UserController.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/api/UserController.java
@@ -1,0 +1,24 @@
+package toy.bookchat.bookchat.domain.user.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import toy.bookchat.bookchat.domain.user.dto.UserProfileResponse;
+import toy.bookchat.bookchat.security.user.UserPrincipal;
+
+@RestController
+@RequestMapping("/v1")
+public class UserController {
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/api/users/profile")
+    public ResponseEntity<UserProfileResponse> userProfile(
+        @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return new ResponseEntity<UserProfileResponse>(UserProfileResponse.of(userPrincipal),
+            HttpStatus.OK);
+    }
+}

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/dto/UserProfileResponse.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/dto/UserProfileResponse.java
@@ -1,0 +1,22 @@
+package toy.bookchat.bookchat.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import toy.bookchat.bookchat.security.user.UserPrincipal;
+
+@Getter
+@Builder
+public class UserProfileResponse {
+
+    private String username;
+    private String userEmail;
+    private String userProfileImageUri;
+
+    public static UserProfileResponse of(UserPrincipal userPrincipal) {
+        return UserProfileResponse.builder()
+            .username(userPrincipal.getName())
+            .userEmail(userPrincipal.getEmail())
+            .userProfileImageUri(userPrincipal.getProfileImageUri())
+            .build();
+    }
+}

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/dto/UserProfileResponse.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/dto/UserProfileResponse.java
@@ -8,13 +8,13 @@ import toy.bookchat.bookchat.security.user.UserPrincipal;
 @Builder
 public class UserProfileResponse {
 
-    private String username;
+    private String userName;
     private String userEmail;
     private String userProfileImageUri;
 
     public static UserProfileResponse of(UserPrincipal userPrincipal) {
         return UserProfileResponse.builder()
-            .username(userPrincipal.getName())
+            .userName(userPrincipal.getName())
             .userEmail(userPrincipal.getEmail())
             .userProfileImageUri(userPrincipal.getProfileImageUri())
             .build();

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/repository/UserRepository.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/repository/UserRepository.java
@@ -1,11 +1,11 @@
 package toy.bookchat.bookchat.domain.user.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import toy.bookchat.bookchat.domain.user.User;
 
-import java.util.Optional;
-
 public interface UserRepository extends JpaRepository<User, Long> {
+
     Optional<User> findByName(String name);
 
     Optional<User> findByEmail(String email);

--- a/back/src/main/java/toy/bookchat/bookchat/security/SecurityConfig.java
+++ b/back/src/main/java/toy/bookchat/bookchat/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package toy.bookchat.bookchat.security;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -9,12 +10,14 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import toy.bookchat.bookchat.security.handler.CustomAuthenticationFailureHandler;
 import toy.bookchat.bookchat.security.handler.CustomAuthenticationSuccessHandler;
+import toy.bookchat.bookchat.security.handler.RestAuthenticationEntryPoint;
 import toy.bookchat.bookchat.security.jwt.JwtAuthenticationFilter;
 import toy.bookchat.bookchat.security.oauth.CustomOAuth2UserService;
 import toy.bookchat.bookchat.security.oauth.HttpCookieOAuth2AuthorizationRequestRepository;
 
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
@@ -23,6 +26,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+    private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -32,9 +36,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
         http.addFilterAt(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
+        http.anonymous().disable();
+
         http.authorizeHttpRequests()
             .antMatchers("/", "/auth").permitAll()
             .anyRequest().authenticated()
+            .and()
+            .exceptionHandling()
+            .authenticationEntryPoint(restAuthenticationEntryPoint)
             .and()
             .formLogin().disable()
             .oauth2Login()

--- a/back/src/main/java/toy/bookchat/bookchat/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/back/src/main/java/toy/bookchat/bookchat/security/handler/CustomAuthenticationSuccessHandler.java
@@ -18,8 +18,8 @@ import toy.bookchat.bookchat.security.CookieUtils;
 import toy.bookchat.bookchat.security.jwt.JwtTokenProvider;
 import toy.bookchat.bookchat.security.oauth.HttpCookieOAuth2AuthorizationRequestRepository;
 
-@Component
 @Slf4j
+@Component
 @RequiredArgsConstructor
 public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 

--- a/back/src/main/java/toy/bookchat/bookchat/security/handler/RestAuthenticationEntryPoint.java
+++ b/back/src/main/java/toy/bookchat/bookchat/security/handler/RestAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package toy.bookchat.bookchat.security.handler;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
+}

--- a/back/src/main/java/toy/bookchat/bookchat/security/jwt/JwtTokenProvider.java
+++ b/back/src/main/java/toy/bookchat/bookchat/security/jwt/JwtTokenProvider.java
@@ -7,7 +7,6 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.SignatureException;
 import java.util.Date;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -17,7 +16,6 @@ import toy.bookchat.bookchat.security.user.UserPrincipal;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class JwtTokenProvider {
 
     public static final String EMAIL = "email";

--- a/back/src/main/java/toy/bookchat/bookchat/security/oauth/CustomOAuth2UserService.java
+++ b/back/src/main/java/toy/bookchat/bookchat/security/oauth/CustomOAuth2UserService.java
@@ -1,5 +1,7 @@
 package toy.bookchat.bookchat.security.oauth;
 
+import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
@@ -9,44 +11,48 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import toy.bookchat.bookchat.domain.user.ROLE;
 import toy.bookchat.bookchat.domain.user.User;
-import toy.bookchat.bookchat.domain.user.domain.ROLE;
 import toy.bookchat.bookchat.domain.user.repository.UserRepository;
 import toy.bookchat.bookchat.security.user.UserPrincipal;
-
-import java.util.Map;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
     private final UserRepository userRepository;
 
     @Override
-    public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
+    public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest)
+        throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(oAuth2UserRequest);
 
         try {
             return processOAuth2User(oAuth2UserRequest, oAuth2User);
-        } catch(AuthenticationException ex) {
+        } catch (AuthenticationException ex) {
             throw new InternalAuthenticationServiceException(ex.getMessage(), ex.getCause());
         }
     }
 
-    private OAuth2User processOAuth2User(OAuth2UserRequest oAuth2UserRequest, OAuth2User oAuth2User) {
+    private OAuth2User processOAuth2User(OAuth2UserRequest oAuth2UserRequest,
+        OAuth2User oAuth2User) {
         String registrationId = oAuth2UserRequest.getClientRegistration().getRegistrationId();
         Map<String, Object> attributes = oAuth2User.getAttributes();
-        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, attributes);
-        if(!StringUtils.hasText(oAuth2UserInfo.getEmail())) {
-            throw new OAuth2AuthenticationProcessingException("Email not found from OAuth2 Provider");
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(registrationId,
+            attributes);
+        if (!StringUtils.hasText(oAuth2UserInfo.getEmail())) {
+            throw new OAuth2AuthenticationProcessingException(
+                "Email not found from OAuth2 Provider");
         }
 
         Optional<User> optionalUser = userRepository.findByEmail(oAuth2UserInfo.getEmail());
         User user;
-        if(optionalUser.isPresent()) {
+        if (optionalUser.isPresent()) {
             user = optionalUser.get();
-            if (!user.getProvider().equals(OAuth2Provider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId()))) {
-                throw new OAuth2AuthenticationProcessingException("you can use this account to login");
+            if (!user.getProvider().equals(OAuth2Provider.valueOf(
+                oAuth2UserRequest.getClientRegistration().getRegistrationId()))) {
+                throw new OAuth2AuthenticationProcessingException(
+                    "you can use this account to login");
             }
             user = updateExistingUser(user, oAuth2UserInfo);
         } else {
@@ -56,14 +62,16 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         return UserPrincipal.create(user, oAuth2User.getAttributes());
     }
 
-    private User registerNewUser(OAuth2UserRequest oAuth2UserRequest, OAuth2UserInfo oAuth2UserInfo) {
+    private User registerNewUser(OAuth2UserRequest oAuth2UserRequest,
+        OAuth2UserInfo oAuth2UserInfo) {
         User user = User.builder()
-                .provider(OAuth2Provider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId()))
-                .name(oAuth2UserInfo.getName())
-                .email(oAuth2UserInfo.getEmail())
-                .profileImageUrl(oAuth2UserInfo.getImageUrl())
-                .role(ROLE.USER)
-                .build();
+            .provider(OAuth2Provider.valueOf(
+                oAuth2UserRequest.getClientRegistration().getRegistrationId()))
+            .name(oAuth2UserInfo.getName())
+            .email(oAuth2UserInfo.getEmail())
+            .profileImageUrl(oAuth2UserInfo.getImageUrl())
+            .role(ROLE.USER)
+            .build();
 
         return userRepository.save(user);
     }

--- a/back/src/main/java/toy/bookchat/bookchat/security/user/UserPrincipal.java
+++ b/back/src/main/java/toy/bookchat/bookchat/security/user/UserPrincipal.java
@@ -18,19 +18,19 @@ public class UserPrincipal implements UserDetails, OAuth2User {
     private Long id;
     private String email;
     private String password;
-    private String username;
+    private String userName;
     private String profileImageUri;
     private Collection<? extends GrantedAuthority> authorities;
     @Setter
     private Map<String, Object> attributes;
 
-    public UserPrincipal(Long id, String email, String password, String username,
+    public UserPrincipal(Long id, String email, String password, String userName,
         String profileImageUri,
         Collection<? extends GrantedAuthority> authorities) {
         this.id = id;
         this.email = email;
         this.password = password;
-        this.username = username;
+        this.userName = userName;
         this.profileImageUri = profileImageUri;
         this.authorities = authorities;
     }
@@ -58,7 +58,7 @@ public class UserPrincipal implements UserDetails, OAuth2User {
 
     @Override
     public String getName() {
-        return this.username;
+        return this.userName;
     }
 
     @Override

--- a/back/src/main/java/toy/bookchat/bookchat/security/user/UserPrincipal.java
+++ b/back/src/main/java/toy/bookchat/bookchat/security/user/UserPrincipal.java
@@ -1,5 +1,9 @@
 package toy.bookchat.bookchat.security.user;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
@@ -8,35 +12,41 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import toy.bookchat.bookchat.domain.user.User;
 
-import java.util.*;
-
 @Getter
 public class UserPrincipal implements UserDetails, OAuth2User {
 
     private Long id;
     private String email;
     private String password;
+    private String username;
+    private String profileImageUri;
     private Collection<? extends GrantedAuthority> authorities;
     @Setter
     private Map<String, Object> attributes;
 
-    public UserPrincipal(Long id, String email, String password, Collection<? extends GrantedAuthority> authorities) {
+    public UserPrincipal(Long id, String email, String password, String username,
+        String profileImageUri,
+        Collection<? extends GrantedAuthority> authorities) {
         this.id = id;
         this.email = email;
         this.password = password;
+        this.username = username;
+        this.profileImageUri = profileImageUri;
         this.authorities = authorities;
     }
 
     public static UserPrincipal create(User user) {
         List<GrantedAuthority> authorities = Collections.singletonList(
-                new SimpleGrantedAuthority("ROLE_" + user.getRole().name())
+            new SimpleGrantedAuthority("ROLE_" + user.getRole().name())
         );
 
         return new UserPrincipal(
-                user.getId(),
-                user.getEmail(),
-                user.getPassword(),
-                authorities
+            user.getId(),
+            user.getEmail(),
+            user.getPassword(),
+            user.getName(),
+            user.getProfileImageUrl(),
+            authorities
         );
     }
 
@@ -48,7 +58,7 @@ public class UserPrincipal implements UserDetails, OAuth2User {
 
     @Override
     public String getName() {
-        return null;
+        return this.username;
     }
 
     @Override

--- a/back/src/test/java/toy/bookchat/bookchat/domain/user/UserControllerTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/domain/user/UserControllerTest.java
@@ -1,15 +1,114 @@
 package toy.bookchat.bookchat.domain.user;
 
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@ExtendWith(RestDocumentationExtension.class)
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import toy.bookchat.bookchat.domain.user.api.UserController;
+import toy.bookchat.bookchat.domain.user.dto.UserProfileResponse;
+import toy.bookchat.bookchat.domain.user.repository.UserRepository;
+import toy.bookchat.bookchat.security.handler.CustomAuthenticationFailureHandler;
+import toy.bookchat.bookchat.security.handler.CustomAuthenticationSuccessHandler;
+import toy.bookchat.bookchat.security.handler.RestAuthenticationEntryPoint;
+import toy.bookchat.bookchat.security.jwt.JwtAuthenticationFilter;
+import toy.bookchat.bookchat.security.jwt.JwtTokenProvider;
+import toy.bookchat.bookchat.security.oauth.CustomOAuth2UserService;
+import toy.bookchat.bookchat.security.oauth.HttpCookieOAuth2AuthorizationRequestRepository;
+import toy.bookchat.bookchat.security.user.UserPrincipal;
+
+@WebMvcTest(controllers = UserController.class,
+    includeFilters = @ComponentScan.Filter(classes = {EnableWebSecurity.class}))
+@Import({JwtAuthenticationFilter.class, RestAuthenticationEntryPoint.class})
+@AutoConfigureRestDocs
 public class UserControllerTest {
 
+    @MockBean
+    CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
+    @MockBean
+    CustomAuthenticationFailureHandler customAuthenticationFailureHandler;
+    @MockBean
+    CustomOAuth2UserService customOAuth2UserService;
+    @MockBean
+    JwtTokenProvider jwtTokenProvider;
+    @MockBean
+    UserRepository userRepository;
+    @MockBean
+    HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
     private MockMvc mockMvc;
+
+    private UserPrincipal getUserPrincipal() {
+        List<GrantedAuthority> authorities = Collections.singletonList(
+            new SimpleGrantedAuthority("ROLE_USER")
+        );
+        UserPrincipal userPrincipal = new UserPrincipal(1L, "test@gmail.com", "password",
+            "testUser", "somethingImageUrl.com", authorities);
+
+        return userPrincipal;
+    }
+
+    @Test
+    public void 인증받지_않은_사용자_요청_401응답() throws Exception {
+        //given
+        mockMvc.perform(get("/v1/api/users/profile"))
+            .andExpect(status().isUnauthorized());
+        //when
+
+        //then
+
+    }
+
+    @Test
+    public void 인증받은_사용자의_요청_200응답() throws Exception {
+        //given
+        mockMvc.perform(get("/v1/api/users/profile")
+                .with(user(getUserPrincipal())))
+            .andExpect(status().isOk());
+
+        //when
+
+        //then
+
+    }
+
+    @Test
+    public void 사용자_프로필_정보_반환() throws Exception {
+        //given
+        String real = objectMapper.writeValueAsString(UserProfileResponse.builder()
+            .userEmail("test@gmail.com")
+            .username("testUser")
+            .userProfileImageUri("somethingImageUrl.com")
+            .build());
+        MvcResult mvcResult = mockMvc.perform(get("/v1/api/users/profile")
+                .with(user(getUserPrincipal())))
+            .andExpect(status().isOk())
+            .andReturn();
+        //when
+
+        //then
+        Assertions.assertThat(mvcResult.getResponse().getContentAsString()).isEqualTo(real);
+
+    }
 
 
 }

--- a/back/src/test/java/toy/bookchat/bookchat/domain/user/UserControllerTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/domain/user/UserControllerTest.java
@@ -96,7 +96,7 @@ public class UserControllerTest {
         //given
         String real = objectMapper.writeValueAsString(UserProfileResponse.builder()
             .userEmail("test@gmail.com")
-            .username("testUser")
+            .userName("testUser")
             .userProfileImageUri("somethingImageUrl.com")
             .build());
         MvcResult mvcResult = mockMvc.perform(get("/v1/api/users/profile")


### PR DESCRIPTION
#29 

인증객체에서 사용자 기초 정보 추출 후 반환
토큰에 사용자 이름, 이메일, 프로필이미지uri까지 포함시키는 방식으로 바꾸면 별도 db 호출 없이 json응답으로 내려줄 수 있어서
포함시키는 정책으로 진행 