### PR TITLE
Fix/66

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -53,7 +53,6 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-    testImplementation 'org.projectlombok:lombok'
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'org.projectlombok:lombok'
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/repository/UserRepository.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/repository/UserRepository.java
@@ -3,10 +3,13 @@ package toy.bookchat.bookchat.domain.user.repository;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import toy.bookchat.bookchat.domain.user.User;
+import toy.bookchat.bookchat.security.oauth.OAuth2Provider;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByName(String name);
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByEmailAndProvider(String email, OAuth2Provider provider);
 }

--- a/back/src/main/java/toy/bookchat/bookchat/security/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/toy/bookchat/bookchat/security/jwt/JwtAuthenticationFilter.java
@@ -49,6 +49,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void validUserRequestByJwt(HttpServletRequest request, String jwt) {
         if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
             String email = jwtTokenProvider.getEmailFromToken(jwt);
+            /*@todo
+             *   사용자의 이메일과 token안에 담긴 oauth2provider로 계정을 선택해서 가져올 수 있도록 함*/
             Optional<User> optionalUser = userRepository.findByEmail(email);
 
             optionalUser.ifPresentOrElse((user -> registerUserAuthentication(request, user)),
@@ -56,7 +58,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     throw new UserNotFoundException("Not Registered User Request");
                 });
         }
-        
+
     }
 
     private void registerUserAuthentication(HttpServletRequest request,

--- a/back/src/main/java/toy/bookchat/bookchat/security/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/toy/bookchat/bookchat/security/jwt/JwtAuthenticationFilter.java
@@ -17,6 +17,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import toy.bookchat.bookchat.domain.user.User;
 import toy.bookchat.bookchat.domain.user.exception.UserNotFoundException;
 import toy.bookchat.bookchat.domain.user.repository.UserRepository;
+import toy.bookchat.bookchat.security.oauth.OAuth2Provider;
 import toy.bookchat.bookchat.security.user.UserPrincipal;
 
 @Component
@@ -49,9 +50,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void validUserRequestByJwt(HttpServletRequest request, String jwt) {
         if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
             String email = jwtTokenProvider.getEmailFromToken(jwt);
+            OAuth2Provider oAuth2TokenProvider = jwtTokenProvider.getOauth2TokenProviderFromToken(
+                jwt);
             /*@todo
              *   사용자의 이메일과 token안에 담긴 oauth2provider로 계정을 선택해서 가져올 수 있도록 함*/
-            Optional<User> optionalUser = userRepository.findByEmail(email);
+            Optional<User> optionalUser = userRepository.findByEmailAndProvider(email,
+                oAuth2TokenProvider);
 
             optionalUser.ifPresentOrElse((user -> registerUserAuthentication(request, user)),
                 () -> {

--- a/back/src/main/java/toy/bookchat/bookchat/security/jwt/JwtTokenProvider.java
+++ b/back/src/main/java/toy/bookchat/bookchat/security/jwt/JwtTokenProvider.java
@@ -21,17 +21,35 @@ public class JwtTokenProvider {
 
     /*@todo
      *   외부 의존성인 io.jwts를 사용하는 것이 아니라 인터페이스를 만들고 그 구현체에서 사용하는 방식으로
-     *   작성하면 이후 io.jwts가 아니라 다른 jwt 구현체를 사용하도록 확장가능*/
+     *   작성하면 이후 io.jwts가 아니라 다른 jwt 구현체를 사용하도록 확장가능
+     *   근데 추상화 비용을 생각해보면 추상화된 토큰 방식의 구현체를 변경할 일이 있을까 싶네,,,
+     *   사용하고 있는 라이브러리가 deprecated되거나 다른 라이브러리로 변경될때를 대비하는 의미로 할까 고민중
+     * */
 
     public static final String EMAIL = "email";
     public static final String SOCIAL_TYPE = "social_type";
     public static final String KAKAO_ACCOUNT = "kakao_account";
+    public static final String OAUTH2_PROVIDER = "oAuth2Provider";
 
-    @Value("${token.secret}")
-    private String secret;
+    private final String secret;
 
-    @Value("${token.expired_time}")
-    private long expiredTime;
+    private final long expiredTime;
+
+    /*@TODO
+     *   @Value를 사용해서 설정 정보를 받는 방식에서
+     *   별도의 Configuration 파일 (예: TokenConfiguration)을 만들어서
+     *   사용하는 것이 설정 값을 한 곳에 묶어서 사용할 수 있고 수정 사항을 한 곳으로
+     *   모아둘 수 있음.
+     *   @Value방식은 빈으로 등록된 후 Reflection을 사용해서 값을 runtime에 동적으로
+     *   넣어주기 때문에 비효율적이고 테스트할 때도 불편했음
+     * https://kkambi.tistory.com/210
+     *https://tuhrig.de/why-using-springs-value-annotation-is-bad/
+     * */
+    public JwtTokenProvider(@Value("${token.secret}") String secret,
+        @Value("${token.expired_time}") long expiredTime) {
+        this.secret = secret;
+        this.expiredTime = expiredTime;
+    }
 
     public String createToken(Authentication authentication) {
         UserPrincipal defaultOAuth2User = (UserPrincipal) authentication.getPrincipal();
@@ -48,11 +66,9 @@ public class JwtTokenProvider {
         } else {
             email = (String) defaultOAuth2User.getAttributes().get(EMAIL);
         }
-        /*@todo
-         *   oauth2 provider 를 토큰에 같이 넘겨주기 -> 우선 token에 대한 조사 분석부터*/
 
         return Jwts.builder()
-            .setSubject(email)
+            .setSubject("bookchat")
             .setClaims(createClaims(oAuth2Provider, email))
             .setIssuedAt(now)
             .setExpiration(expiredDate)
@@ -62,17 +78,25 @@ public class JwtTokenProvider {
 
     private Map<String, Object> createClaims(OAuth2Provider oAuth2Provider, String email) {
         Map<String, Object> claims = new HashMap<>();
-        claims.put("email", email);
-        claims.put("provider", oAuth2Provider.name());
+        claims.put(EMAIL, email);
+        claims.put(OAUTH2_PROVIDER, oAuth2Provider);
         return claims;
     }
 
     public String getEmailFromToken(String token) {
-        return Jwts.parser()
+        return (String) Jwts.parser()
             .setSigningKey(secret)
             .parseClaimsJws(token)
             .getBody()
-            .getSubject();
+            .get(EMAIL);
+    }
+
+    public OAuth2Provider getOauth2TokenProviderFromToken(String token) {
+        return OAuth2Provider.valueOf(Jwts.parser()
+            .setSigningKey(secret)
+            .parseClaimsJws(token)
+            .getBody()
+            .get(OAUTH2_PROVIDER).toString());
     }
 
     public boolean validateToken(String token) {
@@ -90,4 +114,5 @@ public class JwtTokenProvider {
         }
         return false;
     }
+
 }

--- a/back/src/test/java/toy/bookchat/bookchat/domain/user/repository/UserRepositoryTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,46 @@
+package toy.bookchat.bookchat.domain.user.repository;
+
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import toy.bookchat.bookchat.domain.configuration.TestConfig;
+import toy.bookchat.bookchat.domain.user.User;
+import toy.bookchat.bookchat.security.oauth.OAuth2Provider;
+
+@DataJpaTest
+@Import(TestConfig.class)
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    public void 사용자_이메일_OAuth2Provider를_구분으로_조회_성공() throws Exception {
+
+        User user1 = User.builder()
+            .name("user")
+            .email("kaktus418@gmail.com")
+            .provider(OAuth2Provider.kakao)
+            .build();
+
+        User user2 = User.builder()
+            .name("user")
+            .email("kaktus418@gmail.com")
+            .provider(OAuth2Provider.google)
+            .build();
+
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        Optional<User> kakaoUser = userRepository.findByEmailAndProvider(
+            "kaktus418@gmail.com", OAuth2Provider.kakao);
+
+        Optional<User> googleUser = userRepository.findByEmailAndProvider(
+            "kaktus418@gmail.com", OAuth2Provider.google);
+
+        Assertions.assertThat(kakaoUser).isNotEqualTo(googleUser);
+    }
+}

--- a/back/src/test/java/toy/bookchat/bookchat/security/jwt/JwtTokenProviderTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/security/jwt/JwtTokenProviderTest.java
@@ -1,11 +1,11 @@
 package toy.bookchat.bookchat.security.jwt;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -14,26 +14,64 @@ import toy.bookchat.bookchat.security.oauth.OAuth2Provider;
 import toy.bookchat.bookchat.security.user.UserPrincipal;
 
 @ExtendWith(MockitoExtension.class)
-@Slf4j
 class JwtTokenProviderTest {
 
-    JwtTokenProvider tokenProvider = new JwtTokenProvider();
+    JwtTokenProvider tokenProvider = new JwtTokenProvider("hihi", 860000L);
 
-    @Test
-    public void 토큰을_생성한다() throws Exception {
+    private String getToken() {
         Authentication authentication = mock(Authentication.class);
         UserPrincipal userPrincipal = mock(UserPrincipal.class);
-        Map<String, Object> oAuth2Provider = new HashMap<>();
-        oAuth2Provider.put("social_type", OAuth2Provider.kakao);
+
         Map<String, Object> map = new HashMap<>();
-        map.put("email", "kaktus418@gmail.com");
-        oAuth2Provider.put("kakao_account", map);
+        map.put(JwtTokenProvider.EMAIL, "kaktus418@gmail.com");
+        map.put(JwtTokenProvider.OAUTH2_PROVIDER, "kakao");
+
+        Map<String, Object> oAuth2Provider = new HashMap<>();
+        oAuth2Provider.put(JwtTokenProvider.KAKAO_ACCOUNT, map);
+        oAuth2Provider.put(JwtTokenProvider.SOCIAL_TYPE, OAuth2Provider.kakao);
 
         when(authentication.getPrincipal()).thenReturn(userPrincipal);
         when(userPrincipal.getAttributes()).thenReturn(oAuth2Provider);
 
-        String token = tokenProvider.createToken(authentication);
-        log.info(token);
+        return tokenProvider.createToken(authentication);
     }
 
+    @Test
+    public void 토큰을_생성_성공() throws Exception {
+        String token = getToken();
+
+        assertThat(token).isNotBlank();
+        assertThat(token).isInstanceOf(String.class);
+
+    }
+
+    @Test
+    public void 토큰에서_이메일_추출_성공() throws Exception {
+        String token = getToken();
+
+        String email = tokenProvider.getEmailFromToken(token);
+
+        assertThat(email).isEqualTo("kaktus418@gmail.com");
+    }
+
+    @Test
+    public void 토큰에서_Oauth2Provider_추출_성공() throws Exception {
+        String token = getToken();
+
+        OAuth2Provider oauth2TokenProvider = tokenProvider.getOauth2TokenProviderFromToken(token);
+
+        assertThat(oauth2TokenProvider).isEqualTo(OAuth2Provider.kakao);
+    }
+
+    @Test
+    public void 정상_토큰_validation_성공() throws Exception {
+
+        String token = getToken();
+
+        assertThat(tokenProvider.validateToken(token)).isTrue();
+    }
+
+    /*@TODO
+     *   토큰 검증 테스트 추가
+     *   유효시간만료, 토큰 수정여부, 토큰 시그니쳐 검증등*/
 }

--- a/back/src/test/java/toy/bookchat/bookchat/security/jwt/JwtTokenProviderTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/security/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,25 @@
+package toy.bookchat.bookchat.security.jwt;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+
+@SpringBootTest(classes = JwtTokenProvider.class)
+class JwtTokenProviderTest {
+
+    @Autowired
+    JwtTokenProvider tokenProvider;
+
+    @Test
+    public void 토큰을_생성한다() throws Exception {
+        Authentication authentication = mock(Authentication.class);
+
+        when(authentication.getPrincipal()).thenReturn()
+        tokenProvider.createToken(authentication);
+    }
+
+}

--- a/back/src/test/java/toy/bookchat/bookchat/security/jwt/JwtTokenProviderTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/security/jwt/JwtTokenProviderTest.java
@@ -3,23 +3,37 @@ package toy.bookchat.bookchat.security.jwt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
+import toy.bookchat.bookchat.security.oauth.OAuth2Provider;
+import toy.bookchat.bookchat.security.user.UserPrincipal;
 
-@SpringBootTest(classes = JwtTokenProvider.class)
+@ExtendWith(MockitoExtension.class)
+@Slf4j
 class JwtTokenProviderTest {
 
-    @Autowired
-    JwtTokenProvider tokenProvider;
+    JwtTokenProvider tokenProvider = new JwtTokenProvider();
 
     @Test
     public void 토큰을_생성한다() throws Exception {
         Authentication authentication = mock(Authentication.class);
+        UserPrincipal userPrincipal = mock(UserPrincipal.class);
+        Map<String, Object> oAuth2Provider = new HashMap<>();
+        oAuth2Provider.put("social_type", OAuth2Provider.kakao);
+        Map<String, Object> map = new HashMap<>();
+        map.put("email", "kaktus418@gmail.com");
+        oAuth2Provider.put("kakao_account", map);
 
-        when(authentication.getPrincipal()).thenReturn()
-        tokenProvider.createToken(authentication);
+        when(authentication.getPrincipal()).thenReturn(userPrincipal);
+        when(userPrincipal.getAttributes()).thenReturn(oAuth2Provider);
+
+        String token = tokenProvider.createToken(authentication);
+        log.info(token);
     }
 
 }


### PR DESCRIPTION
생각해보니 한 어플에서 구글, 카카오, 네이버 로그인할 때 이렇게 물어보지 안혹 새로운 계정을 생성해서 진행하게 하니까 그 흐름대로 가는게 맞다고 생각이 듭니다 (친숙한 flow ) - 그래서 가입시 token provider로 구분하여 가입 후 진행하도록 했습니다