### PR TITLE
사용자 프로필정보 반환, 사용자 가입시 이미지 파일 확장자 체크, 이미지 url저장 수정

### DIFF
--- a/back/src/main/java/toy/bookchat/bookchat/config/OpenIdTokenConfig.java
+++ b/back/src/main/java/toy/bookchat/bookchat/config/OpenIdTokenConfig.java
@@ -34,6 +34,9 @@ public class OpenIdTokenConfig {
         this.keyFactory = createKeyFactory();
     }
 
+    /* TODO: 2022-09-23 app key로 검증하는거까지 추가하자
+     */
+
     public Key getPublicKey(String keyId, OAuth2Provider oAuth2Provider) {
 
         if (OAuth2Provider.KAKAO.equals(oAuth2Provider)) {

--- a/back/src/main/java/toy/bookchat/bookchat/config/aws/S3Config.java
+++ b/back/src/main/java/toy/bookchat/bookchat/config/aws/S3Config.java
@@ -12,11 +12,15 @@ public class S3Config {
     private final String accessKey;
     private final String secretKey;
     private final String region;
+    private final String imageBucketUrl;
+    private final String bucketName;
 
-    public S3Config(String accessKey, String secretKey, String region) {
+    public S3Config(String accessKey, String secretKey, String region, String imageBucketUrl, String bucketName) {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.region = region;
+        this.imageBucketUrl = imageBucketUrl;
+        this.bucketName = bucketName;
     }
 }
 

--- a/back/src/main/java/toy/bookchat/bookchat/config/aws/S3Config.java
+++ b/back/src/main/java/toy/bookchat/bookchat/config/aws/S3Config.java
@@ -12,15 +12,17 @@ public class S3Config {
     private final String accessKey;
     private final String secretKey;
     private final String region;
-    private final String imageBucketUrl;
     private final String bucketName;
+    private final String imageFolder;
+    private final String imageBucketUrl;
 
-    public S3Config(String accessKey, String secretKey, String region, String imageBucketUrl, String bucketName) {
+    public S3Config(String accessKey, String secretKey, String region, String imageBucketUrl, String bucketName, String imageFolder) {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.region = region;
-        this.imageBucketUrl = imageBucketUrl;
         this.bucketName = bucketName;
+        this.imageFolder = imageFolder;
+        this.imageBucketUrl = imageBucketUrl;
     }
 }
 

--- a/back/src/main/java/toy/bookchat/bookchat/domain/storage/StorageService.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/storage/StorageService.java
@@ -6,6 +6,7 @@ public interface StorageService {
 
     void upload(MultipartFile multipartFile, String fileName);
 
-    /* TODO: 2022-09-14 업로드 가능한 파일타입 검증 메서드
-     */
+    String getFileUrl(String fileName);
+
+    String createFileName(String fileExtension);
 }

--- a/back/src/main/java/toy/bookchat/bookchat/domain/storage/StorageServiceImpl.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/storage/StorageServiceImpl.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import toy.bookchat.bookchat.config.aws.S3Config;
 import toy.bookchat.bookchat.domain.storage.exception.ImageUploadToStorageException;
 
 import java.io.IOException;
@@ -15,13 +16,13 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class StorageServiceImpl implements StorageService{
 
-    public static final String BUCKET_NAME = "bookchat-original";
     private final AmazonS3Client amazonS3Client;
+    private final S3Config s3Config;
 
     @Override
     public void upload(MultipartFile multipartFile, String fileName) {
         try {
-            amazonS3Client.putObject(BUCKET_NAME, fileName,multipartFile.getInputStream(), abstractObjectMetadataFrom(multipartFile));
+            amazonS3Client.putObject(s3Config.getBucketName(), fileName,multipartFile.getInputStream(), abstractObjectMetadataFrom(multipartFile));
         } catch (SdkClientException | IOException exception) {
             throw new ImageUploadToStorageException(exception.getMessage(), exception.getCause());
         }

--- a/back/src/main/java/toy/bookchat/bookchat/domain/storage/StorageServiceImpl.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/storage/StorageServiceImpl.java
@@ -1,6 +1,5 @@
 package toy.bookchat.bookchat.domain.storage;
 
-import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -11,6 +10,9 @@ import toy.bookchat.bookchat.config.aws.S3Config;
 import toy.bookchat.bookchat.domain.storage.exception.ImageUploadToStorageException;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -33,5 +35,28 @@ public class StorageServiceImpl implements StorageService{
         objectMetadata.setContentType(multipartFile.getContentType());
         objectMetadata.setContentLength(multipartFile.getSize());
         return objectMetadata;
+    }
+
+    @Override
+    public String getFileUrl(String fileName) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(s3Config.getImageBucketUrl());
+        stringBuilder.append(fileName);
+        return stringBuilder.toString();
+    }
+
+    /**
+     * '날짜 역순' + UUID로 저장 - S3가 prefix를 사용하여 partitioning을 하기 때문에
+     */
+    @Override
+    public String createFileName(String fileExtension) {
+        StringBuilder stringBuilder = new StringBuilder();
+        String UUIDFileName = UUID.randomUUID().toString();
+        stringBuilder.append(new SimpleDateFormat("yyyy-MM-dd").format(new Date())).reverse();
+        stringBuilder.append(UUIDFileName);
+        stringBuilder.append(".");
+        stringBuilder.append(fileExtension);
+        stringBuilder.insert(0, s3Config.getImageFolder());
+        return stringBuilder.toString();
     }
 }

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/User.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/User.java
@@ -26,7 +26,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
-    private String nickName;
+    private String nickname;
     private String email;
     private String profileImageUrl;
     private ROLE role;
@@ -40,14 +40,14 @@ public class User {
 
     @Builder
     public User(String name, String email, String profileImageUrl, ROLE role,
-        OAuth2Provider provider, String nickName, List<ReadingTaste> readingTastes,
-        Integer defaultProfileImageType) {
+                OAuth2Provider provider, String nickname, List<ReadingTaste> readingTastes,
+                Integer defaultProfileImageType) {
         this.name = name;
         this.email = email;
         this.profileImageUrl = profileImageUrl;
         this.role = role;
         this.provider = provider;
-        this.nickName = nickName;
+        this.nickname = nickname;
         this.readingTastes = readingTastes;
         this.defaultProfileImageType = defaultProfileImageType;
     }

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/api/dto/UserProfileResponse.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/api/dto/UserProfileResponse.java
@@ -8,15 +8,17 @@ import toy.bookchat.bookchat.security.user.UserPrincipal;
 @Builder
 public class UserProfileResponse {
 
-    private String userName;
+    private String userNickname;
     private String userEmail;
     private String userProfileImageUri;
+    private Integer defaultProfileImageType;
 
     public static UserProfileResponse of(UserPrincipal userPrincipal) {
         return UserProfileResponse.builder()
-            .userName(userPrincipal.getName())
+            .userNickname(userPrincipal.getNickname())
             .userEmail(userPrincipal.getEmail())
             .userProfileImageUri(userPrincipal.getProfileImageUri())
+            .defaultProfileImageType(userPrincipal.getDefaultProfileImageType())
             .build();
     }
 }

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/repository/UserRepository.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/repository/UserRepository.java
@@ -13,5 +13,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmailAndProvider(String email, OAuth2Provider provider);
 
-    boolean existsByNickName(String nickname);
+    boolean existsByNickname(String nickname);
 }

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/service/UserServiceImpl.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/service/UserServiceImpl.java
@@ -3,6 +3,7 @@ package toy.bookchat.bookchat.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import toy.bookchat.bookchat.config.aws.S3Config;
 import toy.bookchat.bookchat.domain.storage.StorageService;
 import toy.bookchat.bookchat.domain.user.User;
 import toy.bookchat.bookchat.domain.user.exception.UserAlreadySignUpException;
@@ -19,6 +20,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
+    private final S3Config s3Config;
     private final UserRepository userRepository;
     private final StorageService storageService;
 
@@ -34,8 +36,9 @@ public class UserServiceImpl implements UserService {
 
 
         if(userSignUpRequestDto.hasValidImage()) {
-            String prefixedUUIDFileName = getPrefixedUUIDFileName();
-            saveUser(userSignUpRequestDto, oauth2MemberNumber, userEmail, prefixedUUIDFileName, providerType);
+            String prefixedUUIDFileName = getPrefixedUUIDFileName(userSignUpRequestDto.getFileExtension());
+            String prefixedUUIDFileUrl = getPrefixedUUIDFileUrl(prefixedUUIDFileName);
+            saveUser(userSignUpRequestDto, oauth2MemberNumber, userEmail, prefixedUUIDFileUrl, providerType);
             storageService.upload(userSignUpRequestDto.getUserProfileImage(), prefixedUUIDFileName);
             return;
         }
@@ -43,14 +46,23 @@ public class UserServiceImpl implements UserService {
         saveUser(userSignUpRequestDto, oauth2MemberNumber, userEmail, null, providerType);
     }
 
+    private String getPrefixedUUIDFileUrl(String prefixedUUIDFileName) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(s3Config.getImageBucketUrl());
+        stringBuilder.append(prefixedUUIDFileName);
+        return stringBuilder.toString();
+    }
+
     /**
      * '날짜 역순' + UUID로 저장 - S3가 prefix를 사용하여 partitioning을 하기 때문에
      */
-    private String getPrefixedUUIDFileName() {
+    private String getPrefixedUUIDFileName(String fileExtension) {
         StringBuilder stringBuilder = new StringBuilder();
         String UUIDFileName = UUID.randomUUID().toString();
         stringBuilder.append(new SimpleDateFormat("yyyy-MM-dd").format(new Date())).reverse();
         stringBuilder.append(UUIDFileName);
+        stringBuilder.append(".");
+        stringBuilder.append(fileExtension);
         stringBuilder.insert(0,"user_profile_image/");
         return stringBuilder.toString();
     }

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/service/UserServiceImpl.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/service/UserServiceImpl.java
@@ -25,7 +25,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(readOnly = true)
     public boolean isDuplicatedName(String nickname) {
-        return userRepository.existsByNickName(nickname);
+        return userRepository.existsByNickname(nickname);
     }
 
     @Override

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/service/UserServiceImpl.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/service/UserServiceImpl.java
@@ -3,7 +3,6 @@ package toy.bookchat.bookchat.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import toy.bookchat.bookchat.config.aws.S3Config;
 import toy.bookchat.bookchat.domain.storage.StorageService;
 import toy.bookchat.bookchat.domain.user.User;
 import toy.bookchat.bookchat.domain.user.exception.UserAlreadySignUpException;
@@ -11,16 +10,11 @@ import toy.bookchat.bookchat.domain.user.repository.UserRepository;
 import toy.bookchat.bookchat.domain.user.service.dto.UserSignUpRequestDto;
 import toy.bookchat.bookchat.security.oauth.OAuth2Provider;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Optional;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
-
-    private final S3Config s3Config;
     private final UserRepository userRepository;
     private final StorageService storageService;
 
@@ -33,38 +27,15 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void registerNewUser(UserSignUpRequestDto userSignUpRequestDto, String oauth2MemberNumber, String userEmail, OAuth2Provider providerType) {
-
-
         if(userSignUpRequestDto.hasValidImage()) {
-            String prefixedUUIDFileName = getPrefixedUUIDFileName(userSignUpRequestDto.getFileExtension());
-            String prefixedUUIDFileUrl = getPrefixedUUIDFileUrl(prefixedUUIDFileName);
+            String prefixedUUIDFileName = storageService.createFileName(userSignUpRequestDto.getFileExtension());
+            String prefixedUUIDFileUrl = storageService.getFileUrl(prefixedUUIDFileName);
             saveUser(userSignUpRequestDto, oauth2MemberNumber, userEmail, prefixedUUIDFileUrl, providerType);
             storageService.upload(userSignUpRequestDto.getUserProfileImage(), prefixedUUIDFileName);
             return;
         }
 
         saveUser(userSignUpRequestDto, oauth2MemberNumber, userEmail, null, providerType);
-    }
-
-    private String getPrefixedUUIDFileUrl(String prefixedUUIDFileName) {
-        StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append(s3Config.getImageBucketUrl());
-        stringBuilder.append(prefixedUUIDFileName);
-        return stringBuilder.toString();
-    }
-
-    /**
-     * '날짜 역순' + UUID로 저장 - S3가 prefix를 사용하여 partitioning을 하기 때문에
-     */
-    private String getPrefixedUUIDFileName(String fileExtension) {
-        StringBuilder stringBuilder = new StringBuilder();
-        String UUIDFileName = UUID.randomUUID().toString();
-        stringBuilder.append(new SimpleDateFormat("yyyy-MM-dd").format(new Date())).reverse();
-        stringBuilder.append(UUIDFileName);
-        stringBuilder.append(".");
-        stringBuilder.append(fileExtension);
-        stringBuilder.insert(0,"user_profile_image/");
-        return stringBuilder.toString();
     }
 
     private void saveUser(UserSignUpRequestDto userSignUpRequestDto, String oauth2MemberNumber, String email, String profileImageUrl, OAuth2Provider providerType) {

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/service/dto/SupportedFileExtension.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/service/dto/SupportedFileExtension.java
@@ -1,0 +1,20 @@
+package toy.bookchat.bookchat.domain.user.service.dto;
+
+public enum SupportedFileExtension {
+    WEBP("webp");
+
+    private final String fileExtension;
+
+    SupportedFileExtension(String fileExtension) {
+        this.fileExtension = fileExtension;
+    }
+
+    public static boolean isSupport(String fileExtension) {
+        for( SupportedFileExtension supportedFileExtension : SupportedFileExtension.values()) {
+            if(supportedFileExtension.fileExtension.equals(fileExtension)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/back/src/main/java/toy/bookchat/bookchat/domain/user/service/dto/UserSignUpRequestDto.java
+++ b/back/src/main/java/toy/bookchat/bookchat/domain/user/service/dto/UserSignUpRequestDto.java
@@ -30,8 +30,6 @@ public class UserSignUpRequestDto {
 
     @NotBlank
     String nickname;
-    // TODO: 2022/09/16 userEmail, oauth2Provider는 openidtoken이랑
-    //  request header에 넣어주기로 했었는데 생각해보니 그럼 여기서는 지워도되네
     MultipartFile userProfileImage;
     List<ReadingTaste> readingTastes;
     @NotNull

--- a/back/src/main/java/toy/bookchat/bookchat/security/oauth/CustomOAuth2UserService.java
+++ b/back/src/main/java/toy/bookchat/bookchat/security/oauth/CustomOAuth2UserService.java
@@ -16,7 +16,6 @@ import toy.bookchat.bookchat.domain.user.User;
 import toy.bookchat.bookchat.domain.user.repository.UserRepository;
 import toy.bookchat.bookchat.security.user.UserPrincipal;
 
-@Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 

--- a/back/src/main/java/toy/bookchat/bookchat/security/user/UserPrincipal.java
+++ b/back/src/main/java/toy/bookchat/bookchat/security/user/UserPrincipal.java
@@ -23,15 +23,19 @@ public class UserPrincipal implements UserDetails, OAuth2User {
     private final Collection<? extends GrantedAuthority> authorities;
     @Setter
     private Map<String, Object> attributes;
+    private Integer defaultProfileImageType;
+    private String nickname;
 
     public UserPrincipal(Long id, String email, String userName,
-        String profileImageUri,
+        String nickname, String profileImageUri, Integer defaultProfileImageType,
         Collection<? extends GrantedAuthority> authorities, User user) {
         this.user = user;
         this.id = id;
         this.email = email;
         this.userName = userName;
+        this.nickname = nickname;
         this.profileImageUri = profileImageUri;
+        this.defaultProfileImageType = defaultProfileImageType;
         this.authorities = authorities;
     }
 
@@ -44,7 +48,9 @@ public class UserPrincipal implements UserDetails, OAuth2User {
             user.getId(),
             user.getEmail(),
             user.getName(),
+            user.getNickname(),
             user.getProfileImageUrl(),
+            user.getDefaultProfileImageType(),
             authorities,
             user
         );
@@ -58,6 +64,14 @@ public class UserPrincipal implements UserDetails, OAuth2User {
 
     public User getUser() {
         return user;
+    }
+
+    public Integer getDefaultProfileImageType() {
+        return defaultProfileImageType;
+    }
+
+    public String getNickname() {
+        return nickname;
     }
 
     @Override
@@ -104,5 +118,4 @@ public class UserPrincipal implements UserDetails, OAuth2User {
     public boolean isEnabled() {
         return true;
     }
-
 }

--- a/back/src/main/resources/application-action.yaml
+++ b/back/src/main/resources/application-action.yaml
@@ -46,8 +46,9 @@ aws:
     accessKey: testetsttest
     secretKey: testestsetst
     region: ap-northeast-2
-    imageBucketUrl: 'https://testbucket/testlink/testfile'
     bucketName: 'test-bucket'
+    imageFolder: 'user_profile_image/'
+    imageBucketUrl: 'https://testbucket/testlink/testfile'
 
 oauth2:
   kakaoURI: 'https://kauth.kakao.com/.well-known/jwks.json'

--- a/back/src/main/resources/application-action.yaml
+++ b/back/src/main/resources/application-action.yaml
@@ -46,6 +46,8 @@ aws:
     accessKey: testetsttest
     secretKey: testestsetst
     region: ap-northeast-2
+    imageBucketUrl: 'https://testbucket/testlink/testfile'
+    bucketName: 'test-bucket'
 
 oauth2:
   kakaoURI: 'https://kauth.kakao.com/.well-known/jwks.json'

--- a/back/src/test/java/toy/bookchat/bookchat/domain/AuthenticationTestExtension.java
+++ b/back/src/test/java/toy/bookchat/bookchat/domain/AuthenticationTestExtension.java
@@ -6,7 +6,10 @@ import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import toy.bookchat.bookchat.security.ipblock.IpBlockManager;
-
+/*
+    controller 테스트는 security까지 포함시켜 테스트하여 restdoc 문서에
+    token, provider_type과 같은 정보가 포함되도록 진행
+ */
 public abstract class AuthenticationTestExtension {
 
     @MockBean

--- a/back/src/test/java/toy/bookchat/bookchat/domain/book/api/BookControllerTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/domain/book/api/BookControllerTest.java
@@ -130,7 +130,7 @@ public class BookControllerTest extends AuthenticationTestExtension {
             .profileImageUrl("somethingImageUrl@naver.com")
             .build();
 
-        return new UserPrincipal(1L, user.getEmail(), user.getName(), user.getProfileImageUrl(),
+        return new UserPrincipal(1L, user.getEmail(), user.getName(), user.getNickname(), user.getProfileImageUrl(), user.getDefaultProfileImageType(),
             authorities, user);
 
     }

--- a/back/src/test/java/toy/bookchat/bookchat/domain/bookshelf/api/BookShelfControllerTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/domain/bookshelf/api/BookShelfControllerTest.java
@@ -141,8 +141,8 @@ public class BookShelfControllerTest extends AuthenticationTestExtension {
             .profileImageUrl("somethingImageUrl@naver.com")
             .build();
 
-        return new UserPrincipal(1L, user.getEmail(), user.getName(), user.getProfileImageUrl(),
-            authorities, user);
+        return new UserPrincipal(1L, user.getEmail(), user.getName(), user.getNickname(), user.getProfileImageUrl(),
+            user.getDefaultProfileImageType(), authorities, user);
     }
 
     private BookShelfRequestDto getBookShelfRequestDto(ReadingStatus readingStatus) {

--- a/back/src/test/java/toy/bookchat/bookchat/domain/storage/StorageServiceTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/domain/storage/StorageServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
+import toy.bookchat.bookchat.config.aws.S3Config;
 import toy.bookchat.bookchat.domain.storage.exception.ImageUploadToStorageException;
 
 import java.io.File;
@@ -28,6 +29,8 @@ import static org.mockito.Mockito.*;
 class StorageServiceTest {
 
     @Mock
+    S3Config s3Config;
+    @Mock
     AmazonS3Client amazonS3Client;
 
     @InjectMocks
@@ -36,6 +39,7 @@ class StorageServiceTest {
     @Test
     public void 이미지_파일_업로드_성공() throws Exception {
         MultipartFile multipartFile = mock(MultipartFile.class);
+        when(s3Config.getBucketName()).thenReturn("testBucketName");
         when(multipartFile.getInputStream()).thenReturn(mock(InputStream.class));
         storageService.upload(multipartFile,"test");
         verify(amazonS3Client).putObject(anyString(), anyString(), any(InputStream.class), any(ObjectMetadata.class));
@@ -44,6 +48,7 @@ class StorageServiceTest {
     @Test
     public void 이미지_업로드중_S3예외_발생시_커스텀예외_던지기_성공() throws Exception {
         when(amazonS3Client.putObject(any(),any(), any(), any())).thenThrow(ImageUploadToStorageException.class);
+        when(s3Config.getBucketName()).thenReturn("testBucketName");
         assertThatThrownBy(() -> {
             storageService.upload(mock(MultipartFile.class), "test");
         }).isInstanceOf(ImageUploadToStorageException.class);
@@ -52,6 +57,7 @@ class StorageServiceTest {
     @Test
     public void 이미지_업로드중_IO예외_발생시_커스텀예외_던지기_성공() throws Exception {
         MultipartFile multipartFile = mock(MultipartFile.class);
+        when(s3Config.getBucketName()).thenReturn("testBucketName");
         when(multipartFile.getInputStream()).thenThrow(IOException.class);
         assertThatThrownBy(() -> {
             storageService.upload(multipartFile, "test");

--- a/back/src/test/java/toy/bookchat/bookchat/domain/user/api/UserControllerTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/domain/user/api/UserControllerTest.java
@@ -104,7 +104,7 @@ public class UserControllerTest extends AuthenticationTestExtension {
             .build();
 
         return new UserPrincipal(1L, user.getEmail(),
-            user.getName(), user.getProfileImageUrl(), authorities, user);
+            user.getName(), user.getNickname(), user.getProfileImageUrl(), user.getDefaultProfileImageType(), authorities, user);
     }
 
     @Test
@@ -129,15 +129,18 @@ public class UserControllerTest extends AuthenticationTestExtension {
 
         String real = objectMapper.writeValueAsString(UserProfileResponse.builder()
             .userEmail("test@gmail.com")
-            .userName("testkakao")
+            .userNickname("nickname")
             .userProfileImageUri("somethingImageUrl@naver.com")
+            .defaultProfileImageType(1)
             .build());
 
         User user = User.builder()
             .email("test@gmail.com")
             .name("testkakao")
+            .nickname("nickname")
             .role(ROLE.USER)
             .profileImageUrl("somethingImageUrl@naver.com")
+            .defaultProfileImageType(1)
             .build();
 
         when(userRepository.findByName(any())).thenReturn(Optional.of(user));

--- a/back/src/test/java/toy/bookchat/bookchat/domain/user/repository/UserRepositoryTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/domain/user/repository/UserRepositoryTest.java
@@ -51,19 +51,19 @@ class UserRepositoryTest {
             .name("user")
             .email("kaktus418@gmail.com")
             .provider(OAuth2Provider.KAKAO)
-            .nickName("nickname")
+            .nickname("nickname")
             .build();
 
         userRepository.save(user);
 
-        boolean result = userRepository.existsByNickName("nickname");
+        boolean result = userRepository.existsByNickname("nickname");
 
         assertThat(result).isTrue();
     }
 
     @Test
     public void 사용자_nickname_존재하지않을시_false_반환_성공() throws Exception {
-        boolean result = userRepository.existsByNickName("nickname");
+        boolean result = userRepository.existsByNickname("nickname");
 
         assertThat(result).isFalse();
     }

--- a/back/src/test/java/toy/bookchat/bookchat/domain/user/service/UserServiceTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/domain/user/service/UserServiceTest.java
@@ -17,7 +17,6 @@ import toy.bookchat.bookchat.domain.user.User;
 import toy.bookchat.bookchat.domain.user.exception.UserAlreadySignUpException;
 import toy.bookchat.bookchat.domain.user.repository.UserRepository;
 import toy.bookchat.bookchat.domain.user.service.dto.UserSignUpRequestDto;
-import toy.bookchat.bookchat.security.oauth.OAuth2Provider;
 
 import java.util.Optional;
 
@@ -34,14 +33,14 @@ class UserServiceTest {
     @Test
     public void 사용자_중복된_nickname_체크() throws Exception {
 
-        when(userRepository.existsByNickName(anyString())).thenReturn(true);
+        when(userRepository.existsByNickname(anyString())).thenReturn(true);
         boolean result = userService.isDuplicatedName("test");
         assertThat(result).isTrue();
     }
 
     @Test
     public void 사용자가_중복되지_않은_nickname_체크() throws Exception {
-        when(userRepository.existsByNickName(anyString())).thenReturn(false);
+        when(userRepository.existsByNickname(anyString())).thenReturn(false);
         boolean result = userService.isDuplicatedName("test");
         assertThat(result).isFalse();
     }

--- a/back/src/test/java/toy/bookchat/bookchat/domain/user/service/UserServiceTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/domain/user/service/UserServiceTest.java
@@ -26,8 +26,6 @@ import java.util.Optional;
 class UserServiceTest {
 
     @Mock
-    S3Config s3Config;
-    @Mock
     UserRepository userRepository;
     @Mock
     StorageService storageService;
@@ -53,7 +51,7 @@ class UserServiceTest {
     public void 처음_가입하는_회원의_경우_회원가입_성공() throws Exception {
         UserSignUpRequestDto userSignUpRequestDto = mock(UserSignUpRequestDto.class);
         User mockUser = mock(User.class);
-        when(s3Config.getImageBucketUrl()).thenReturn("testBucketUrl");
+        when(storageService.getFileUrl(any())).thenReturn("testBucketUrl");
         when(userSignUpRequestDto.hasValidImage()).thenReturn(true);
         when(userSignUpRequestDto.getUser(any(), any(), any(), any())).thenReturn(mockUser);
         userService.registerNewUser(userSignUpRequestDto, "memberNumber","test@gmail.com", KAKAO);

--- a/back/src/test/java/toy/bookchat/bookchat/security/token/openid/OpenIdAuthenticationFilterTest.java
+++ b/back/src/test/java/toy/bookchat/bookchat/security/token/openid/OpenIdAuthenticationFilterTest.java
@@ -65,7 +65,7 @@ class OpenIdAuthenticationFilterTest {
             .name("352kakao")
             .provider(OAuth2Provider.KAKAO)
             .email("test@gmail.com")
-            .nickName("testnick")
+            .nickname("testnick")
             .role(ROLE.USER)
             .build();
 


### PR DESCRIPTION
s3에서 이미지 트랜잭션 롤백을 제공해주지 않기 때문에 DB에 우선 파일 url 저장 후 s3에 저장하여 
s3에서 예외가 터지면 db를 롤백시켜주도록 배치했습니다