### PR TITLE
고민폴더 책별로 구분되도록 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -513,6 +513,7 @@ include::{snippets}/get-agonies/request-headers.adoc[]
 
 `Request`
 
+include::{snippets}/get-agonies/path-parameters.adoc[]
 include::{snippets}/get-agonies/request-parameters.adoc[]
 include::{snippets}/get-agonies/http-request.adoc[]
 
@@ -531,6 +532,7 @@ include::{snippets}/delete-agony/request-headers.adoc[]
 
 `Request`
 
+include::{snippets}/delete-agony/path-parameters.adoc[]
 include::{snippets}/delete-agony/http-request.adoc[]
 
 `Response`

--- a/src/docs/asciidoc/index.html
+++ b/src/docs/asciidoc/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.18">
 <title>BookChat API Documentation</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -84,10 +84,10 @@ code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;
 ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
 ul,ol{margin-left:1.5em}
 ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
 ul.circle{list-style-type:circle}
 ul.disc{list-style-type:disc}
+ul.square{list-style-type:square}
+ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
 ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
 dl dt{margin-bottom:.3125em;font-weight:bold}
 dl dd{margin-bottom:1.25em}
@@ -605,7 +605,7 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 419
 Host: bookchat.link
 
-{"refreshToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY4MDM5NjIsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.Yzo49FxfRy1BC_McVUAh84Zz6kyQU_6OR1OH3Qu58tg"}</code></pre>
+{"refreshToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY4NjkwMzMsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.Y_MNKj2xDultSc9MF73QOqbaDx8XK5i7-Xfcyo1JU1Y"}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -650,7 +650,7 @@ Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
 Content-Length: 836
 
-{"accessToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzU1OTU3NjIsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.tNXQYDGPbBWBa6M4uBWcSqH30HADtcb0ae2WxT-F-mQ","refreshToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY4MDM5NjIsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.Yzo49FxfRy1BC_McVUAh84Zz6kyQU_6OR1OH3Qu58tg"}</code></pre>
+{"accessToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY4NjkwMzMsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.Y_MNKj2xDultSc9MF73QOqbaDx8XK5i7-Xfcyo1JU1Y","refreshToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY4NjkwMzMsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.Y_MNKj2xDultSc9MF73QOqbaDx8XK5i7-Xfcyo1JU1Y"}</code></pre>
 </div>
 </div>
 </div>
@@ -1664,7 +1664,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb
 Content-Length: 204
 Host: bookchat.link
 
-{"bookRequest":{"isbn":"124151214","title":"effectiveJava","authors":["Joshua"],"publisher":"oreilly","bookCoverImageUrl":"bookCoverImage.com","publishAt":"2023-02-05"},"readingStatus":"WISH","star":null}</code></pre>
+{"bookRequest":{"isbn":"124151214","title":"effectiveJava","authors":["Joshua"],"publisher":"oreilly","bookCoverImageUrl":"bookCoverImage.com","publishAt":"2023-02-06"},"readingStatus":"WISH","star":null}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1776,7 +1776,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb
 Content-Length: 207
 Host: bookchat.link
 
-{"bookRequest":{"isbn":"124151214","title":"effectiveJava","authors":["Joshua"],"publisher":"oreilly","bookCoverImageUrl":"bookCoverImage.com","publishAt":"2023-02-05"},"readingStatus":"READING","star":null}</code></pre>
+{"bookRequest":{"isbn":"124151214","title":"effectiveJava","authors":["Joshua"],"publisher":"oreilly","bookCoverImageUrl":"bookCoverImage.com","publishAt":"2023-02-06"},"readingStatus":"READING","star":null}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1894,7 +1894,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb
 Content-Length: 210
 Host: bookchat.link
 
-{"bookRequest":{"isbn":"124151214","title":"effectiveJava","authors":["Joshua"],"publisher":"oreilly","bookCoverImageUrl":"bookCoverImage.com","publishAt":"2023-02-05"},"readingStatus":"COMPLETE","star":"FOUR"}</code></pre>
+{"bookRequest":{"isbn":"124151214","title":"effectiveJava","authors":["Joshua"],"publisher":"oreilly","bookCoverImageUrl":"bookCoverImage.com","publishAt":"2023-02-06"},"readingStatus":"COMPLETE","star":"FOUR"}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2087,7 +2087,7 @@ Host: bookchat.link</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"pageMeta":{"totalElements":1,"totalPages":1,"pageSize":1,"pageNumber":0,"offset":0,"first":true,"last":true,"empty":false},"contents":[{"bookId":1,"title":"effectiveJava","isbn":"12345","bookCoverImageUrl":"testBookCoverImageUrl","publishAt":"2023-02-05","authors":["joshua"],"publisher":"testBookCoverImageUrl","star":null,"pages":0}]}</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"pageMeta":{"totalElements":1,"totalPages":1,"pageSize":1,"pageNumber":0,"offset":0,"first":true,"last":true,"empty":false},"contents":[{"bookId":1,"title":"effectiveJava","isbn":"12345","bookCoverImageUrl":"testBookCoverImageUrl","publishAt":"2023-02-06","authors":["joshua"],"publisher":"testBookCoverImageUrl","star":null,"pages":0}]}</code></pre>
 </div>
 </div>
 <hr>
@@ -2265,7 +2265,7 @@ Host: bookchat.link</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"pageMeta":{"totalElements":1,"totalPages":1,"pageSize":1,"pageNumber":0,"offset":0,"first":true,"last":true,"empty":false},"contents":[{"bookId":1,"title":"effectiveJava","isbn":"12345","bookCoverImageUrl":"testBookCoverImageUrl","publishAt":"2023-02-05","authors":["joshua"],"publisher":"testBookCoverImageUrl","star":null,"pages":152}]}</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"pageMeta":{"totalElements":1,"totalPages":1,"pageSize":1,"pageNumber":0,"offset":0,"first":true,"last":true,"empty":false},"contents":[{"bookId":1,"title":"effectiveJava","isbn":"12345","bookCoverImageUrl":"testBookCoverImageUrl","publishAt":"2023-02-06","authors":["joshua"],"publisher":"testBookCoverImageUrl","star":null,"pages":152}]}</code></pre>
 </div>
 </div>
 <hr>
@@ -2443,7 +2443,7 @@ Host: bookchat.link</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"pageMeta":{"totalElements":1,"totalPages":1,"pageSize":1,"pageNumber":0,"offset":0,"first":true,"last":true,"empty":false},"contents":[{"bookId":1,"title":"effectiveJava","isbn":"12345","bookCoverImageUrl":"testBookCoverImageUrl","publishAt":"2023-02-05","authors":["joshua"],"publisher":"testBookCoverImageUrl","star":"FOUR_HALF","pages":0}]}</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"pageMeta":{"totalElements":1,"totalPages":1,"pageSize":1,"pageNumber":0,"offset":0,"first":true,"last":true,"empty":false},"contents":[{"bookId":1,"title":"effectiveJava","isbn":"12345","bookCoverImageUrl":"testBookCoverImageUrl","publishAt":"2023-02-06","authors":["joshua"],"publisher":"testBookCoverImageUrl","star":"FOUR_HALF","pages":0}]}</code></pre>
 </div>
 </div>
 <hr>
@@ -2500,7 +2500,7 @@ Host: bookchat.link</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelf/books/existence?isbn=1234567891011+0123456789&amp;publishAt=2023-02-05 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelf/books/existence?isbn=1234567891011+0123456789&amp;publishAt=2023-02-06 HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -3239,7 +3239,7 @@ Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
 Content-Length: 116
 
-{"reportTitle":"재미있네","reportContent":"다 읽은 후기 알려드립니다","reportCreatedAt":"2023-02-05"}</code></pre>
+{"reportTitle":"재미있네","reportContent":"다 읽은 후기 알려드립니다","reportCreatedAt":"2023-02-06"}</code></pre>
 </div>
 </div>
 <hr>
@@ -3445,7 +3445,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 9. /v1/api/bookshelf/books/{bookId}/agonies</caption>
+<caption class="title">Table 9. /v1/api/bookshelf/{bookShelfId}/agonies</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3458,8 +3458,8 @@ X-Frame-Options: DENY</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Book Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
 </tr>
 </tbody>
 </table>
@@ -3493,7 +3493,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelf/books/1/agonies HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelf/1/agonies HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 42
@@ -3546,6 +3546,25 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 10. /v1/api/bookshelf/{bookShelfId}/agonies</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3576,7 +3595,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/agonies?size=2&amp;sort=id,DESC&amp;postCursorId=1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelf/1/agonies?size=2&amp;sort=id,DESC&amp;postCursorId=1 HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -3663,7 +3682,7 @@ Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
 Content-Length: 256
 
-{"agonyResponseList":[{"agonyId":1,"title":"고민1","hexColorCode":"빨강"},{"agonyId":2,"title":"고민2","hexColorCode":"파랑"}],"cursorMeta":{"sliceSize":2,"contentSize":2,"hasContent":true,"hasNext":true,"nextCursorId":2,"first":true,"last":false}}</code></pre>
+{"agonyResponseList":[{"agonyId":1,"title":"고민1","hexColorCode":"빨강"},{"agonyId":2,"title":"고민2","hexColorCode":"파랑"}],"cursorMeta":{"sliceSize":2,"contentSize":2,"hasContent":true,"hasNext":true,"nextCursorId":2,"last":false,"first":true}}</code></pre>
 </div>
 </div>
 <hr>
@@ -3694,9 +3713,32 @@ Content-Length: 256
 <div class="paragraph">
 <p><code>Request</code></p>
 </div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 11. /v1/api/bookshelf/{bookShelfId}/agonies/{agoniesIds}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>agoniesIds</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">삭제할 고민폴더 ID</p></td>
+</tr>
+</tbody>
+</table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /v1/api/agonies/1,2,3 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /v1/api/bookshelf/1/agonies/1,2,3 HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -3745,7 +3787,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 10. /v1/api/agonies/{agonyId}</caption>
+<caption class="title">Table 12. /v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3757,6 +3799,10 @@ X-Frame-Options: DENY</code></pre>
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>agonyId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Agony Id</p></td>
@@ -3793,7 +3839,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/agonies/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelf/1/agonies/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 55
@@ -3850,7 +3896,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 11. /v1/api/agonies/{agonyId}/records</caption>
+<caption class="title">Table 13. /v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3862,6 +3908,10 @@ X-Frame-Options: DENY</code></pre>
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>agonyId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Agony Id</p></td>
@@ -3898,7 +3948,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/agonies/1/records HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelf/1/agonies/1/records HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 36
@@ -3951,7 +4001,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 12. /v1/api/agonies/{agonyId}/records</caption>
+<caption class="title">Table 14. /v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3963,6 +4013,10 @@ X-Frame-Options: DENY</code></pre>
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>agonyId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Agony Id</p></td>
@@ -4000,7 +4054,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/agonies/1/records?postCursorId=1&amp;size=2&amp;sort=id,ASC HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelf/1/agonies/1/records?postCursorId=1&amp;size=2&amp;sort=id,ASC HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -4092,7 +4146,7 @@ Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
 Content-Length: 360
 
-{"agonyRecordResponseList":[{"agonyRecordId":2,"agonyRecordTitle":"title1","agonyRecordContent":"content1","createdAt":"2023-02-05"},{"agonyRecordId":3,"agonyRecordTitle":"title2","agonyRecordContent":"content2","createdAt":"2023-02-05"}],"cursorMeta":{"sliceSize":2,"contentSize":2,"hasContent":true,"hasNext":false,"nextCursorId":3,"first":true,"last":true}}</code></pre>
+{"agonyRecordResponseList":[{"agonyRecordId":2,"agonyRecordTitle":"title1","agonyRecordContent":"content1","createdAt":"2023-02-06"},{"agonyRecordId":3,"agonyRecordTitle":"title2","agonyRecordContent":"content2","createdAt":"2023-02-06"}],"cursorMeta":{"sliceSize":2,"contentSize":2,"hasContent":true,"hasNext":false,"nextCursorId":3,"last":true,"first":true}}</code></pre>
 </div>
 </div>
 </div>
@@ -4123,7 +4177,7 @@ Content-Length: 360
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 13. /v1/api/agonies/{agonyId}/records/{recordId}</caption>
+<caption class="title">Table 15. /v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records/{recordId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -4136,6 +4190,10 @@ Content-Length: 360
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>agonyId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Agony Id</p></td>
 </tr>
@@ -4147,7 +4205,7 @@ Content-Length: 360
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /v1/api/agonies/1/records/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /v1/api/bookshelf/1/agonies/1/records/1 HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -4196,7 +4254,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 14. /v1/api/agonies/{agonyId}/records/{recordId}</caption>
+<caption class="title">Table 16. /v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records/{recordId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -4208,6 +4266,10 @@ X-Frame-Options: DENY</code></pre>
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>agonyId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Agony Id</p></td>
@@ -4248,7 +4310,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/agonies/1/records/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelf/1/agonies/1/records/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 97
@@ -4415,7 +4477,7 @@ test
 Content-Disposition: form-data; name=createChatRoomRequest
 Content-Type: application/json
 
-{"roomName":"effective java 부수는 방","roomSize":5,"defaultRoomImageType":1,"hashTags":["Java","스터디"],"bookRequest":{"isbn":"124151214","title":"effective java","authors":["joshua"],"publisher":"insight","bookCoverImageUrl":"testImageUrl","publishAt":"2023-02-05"}}
+{"roomName":"effective java 부수는 방","roomSize":5,"defaultRoomImageType":1,"hashTags":["Java","스터디"],"bookRequest":{"isbn":"124151214","title":"effective java","authors":["joshua"],"publisher":"insight","bookCoverImageUrl":"testImageUrl","publishAt":"2023-02-06"}}
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
 </div>
 </div>
@@ -4602,9 +4664,9 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
-Content-Length: 861
+Content-Length: 865
 
-{"chatRoomResponseList":[{"roomId":1,"roomName":"이펙티브 자바 부수는 방","roomSid":"secret1","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":1,"lastActiveTime":"2023-02-05T19:45:55.852575","lastChatContent":"안녕"},{"roomId":2,"roomName":"이펙티브 코틀린 부수는 방","roomSid":"secret2","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":2,"lastActiveTime":"2023-02-05T19:45:55.85259","lastChatContent":"잘가"},{"roomId":3,"roomName":"토비의 스프링 부수는 방","roomSid":"secret3","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":3,"lastActiveTime":"2023-02-05T19:45:55.852603","lastChatContent":"이거 모르겠음"}],"cursorMeta":{"sliceSize":3,"contentSize":3,"hasContent":true,"hasNext":true,"nextCursorId":3,"first":true,"last":false}}</code></pre>
+{"chatRoomResponseList":[{"roomId":1,"roomName":"이펙티브 자바 부수는 방","roomSid":"secret1","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":1,"lastActiveTime":"2023-02-06T13:50:28.8825137","lastChatContent":"안녕"},{"roomId":2,"roomName":"이펙티브 코틀린 부수는 방","roomSid":"secret2","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":2,"lastActiveTime":"2023-02-06T13:50:28.8825137","lastChatContent":"잘가"},{"roomId":3,"roomName":"토비의 스프링 부수는 방","roomSid":"secret3","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":3,"lastActiveTime":"2023-02-06T13:50:28.8825137","lastChatContent":"이거 모르겠음"}],"cursorMeta":{"sliceSize":3,"contentSize":3,"hasContent":true,"hasNext":true,"nextCursorId":3,"last":false,"first":true}}</code></pre>
 </div>
 </div>
 </div>
@@ -4758,14 +4820,14 @@ Content-Length: 861
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2023-02-05 12:16:09 +0900
+Last updated 2023-02-06 13:56:53 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>
 <script>
 if (!hljs.initHighlighting.called) {
   hljs.initHighlighting.called = true
-  ;[].slice.call(document.querySelectorAll('pre.highlight > code')).forEach(function (el) { hljs.highlightBlock(el) })
+  ;[].slice.call(document.querySelectorAll('pre.highlight > code[data-lang]')).forEach(function (el) { hljs.highlightBlock(el) })
 }
 </script>
 </body>

--- a/src/docs/asciidoc/index.html
+++ b/src/docs/asciidoc/index.html
@@ -605,7 +605,7 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 419
 Host: bookchat.link
 
-{"refreshToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY4NjkwMzMsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.Y_MNKj2xDultSc9MF73QOqbaDx8XK5i7-Xfcyo1JU1Y"}</code></pre>
+{"refreshToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY4NzYxOTQsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.X-cbVhpsldTQZf8jCz1OoCtfLKN26BfVCWd6PNsJz7U"}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -650,7 +650,7 @@ Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
 Content-Length: 836
 
-{"accessToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY4NjkwMzMsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.Y_MNKj2xDultSc9MF73QOqbaDx8XK5i7-Xfcyo1JU1Y","refreshToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY4NjkwMzMsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.Y_MNKj2xDultSc9MF73QOqbaDx8XK5i7-Xfcyo1JU1Y"}</code></pre>
+{"accessToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY4NzYxOTQsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.X-cbVhpsldTQZf8jCz1OoCtfLKN26BfVCWd6PNsJz7U","refreshToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY4NzYxOTQsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.X-cbVhpsldTQZf8jCz1OoCtfLKN26BfVCWd6PNsJz7U"}</code></pre>
 </div>
 </div>
 </div>
@@ -1658,7 +1658,7 @@ Content-Length: 234
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelf/books HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelves HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 204
@@ -1770,7 +1770,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelf/books HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelves HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 207
@@ -1888,7 +1888,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelf/books HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelves HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 210
@@ -1976,7 +1976,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelf/books?readingStatus=WISH&amp;size=5&amp;page=1&amp;sort=id,DESC HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelves?readingStatus=WISH&amp;size=5&amp;page=1&amp;sort=id,DESC HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -1999,9 +1999,9 @@ Host: bookchat.link</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>contents[].bookId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>contents[].bookShelfId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Book Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>contents[].title</code></p></td>
@@ -2087,7 +2087,7 @@ Host: bookchat.link</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"pageMeta":{"totalElements":1,"totalPages":1,"pageSize":1,"pageNumber":0,"offset":0,"first":true,"last":true,"empty":false},"contents":[{"bookId":1,"title":"effectiveJava","isbn":"12345","bookCoverImageUrl":"testBookCoverImageUrl","publishAt":"2023-02-06","authors":["joshua"],"publisher":"testBookCoverImageUrl","star":null,"pages":0}]}</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"pageMeta":{"totalElements":1,"totalPages":1,"pageSize":1,"pageNumber":0,"offset":0,"first":true,"last":true,"empty":false},"contents":[{"bookShelfId":1,"title":"effectiveJava","isbn":"12345","bookCoverImageUrl":"testBookCoverImageUrl","publishAt":"2023-02-06","authors":["joshua"],"publisher":"testBookCoverImageUrl","star":null,"pages":0}]}</code></pre>
 </div>
 </div>
 <hr>
@@ -2154,7 +2154,7 @@ Host: bookchat.link</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelf/books?readingStatus=READING&amp;size=5&amp;page=1&amp;sort=id,DESC HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelves?readingStatus=READING&amp;size=5&amp;page=1&amp;sort=id,DESC HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -2177,9 +2177,9 @@ Host: bookchat.link</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>contents[].bookId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>contents[].bookShelfId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Book Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>contents[].title</code></p></td>
@@ -2265,7 +2265,7 @@ Host: bookchat.link</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"pageMeta":{"totalElements":1,"totalPages":1,"pageSize":1,"pageNumber":0,"offset":0,"first":true,"last":true,"empty":false},"contents":[{"bookId":1,"title":"effectiveJava","isbn":"12345","bookCoverImageUrl":"testBookCoverImageUrl","publishAt":"2023-02-06","authors":["joshua"],"publisher":"testBookCoverImageUrl","star":null,"pages":152}]}</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"pageMeta":{"totalElements":1,"totalPages":1,"pageSize":1,"pageNumber":0,"offset":0,"first":true,"last":true,"empty":false},"contents":[{"bookShelfId":1,"title":"effectiveJava","isbn":"12345","bookCoverImageUrl":"testBookCoverImageUrl","publishAt":"2023-02-06","authors":["joshua"],"publisher":"testBookCoverImageUrl","star":null,"pages":152}]}</code></pre>
 </div>
 </div>
 <hr>
@@ -2332,7 +2332,7 @@ Host: bookchat.link</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelf/books?readingStatus=COMPLETE&amp;size=5&amp;page=1&amp;sort=id,DESC HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelves?readingStatus=COMPLETE&amp;size=5&amp;page=1&amp;sort=id,DESC HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -2355,9 +2355,9 @@ Host: bookchat.link</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>contents[].bookId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>contents[].bookShelfId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Book Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>contents[].title</code></p></td>
@@ -2443,7 +2443,7 @@ Host: bookchat.link</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"pageMeta":{"totalElements":1,"totalPages":1,"pageSize":1,"pageNumber":0,"offset":0,"first":true,"last":true,"empty":false},"contents":[{"bookId":1,"title":"effectiveJava","isbn":"12345","bookCoverImageUrl":"testBookCoverImageUrl","publishAt":"2023-02-06","authors":["joshua"],"publisher":"testBookCoverImageUrl","star":"FOUR_HALF","pages":0}]}</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"pageMeta":{"totalElements":1,"totalPages":1,"pageSize":1,"pageNumber":0,"offset":0,"first":true,"last":true,"empty":false},"contents":[{"bookShelfId":1,"title":"effectiveJava","isbn":"12345","bookCoverImageUrl":"testBookCoverImageUrl","publishAt":"2023-02-06","authors":["joshua"],"publisher":"testBookCoverImageUrl","star":"FOUR_HALF","pages":0}]}</code></pre>
 </div>
 </div>
 <hr>
@@ -2500,7 +2500,7 @@ Host: bookchat.link</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelf/books/existence?isbn=1234567891011+0123456789&amp;publishAt=2023-02-06 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelves/book?isbn=1234567891011+0123456789&amp;publishAt=2023-02-06 HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -2528,11 +2528,6 @@ Host: bookchat.link</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">책이 등록된 서재 ID</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">책 ID</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>readingStatus</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">서재에 등록된 책의 현재 상태</p></td>
@@ -2550,9 +2545,9 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
-Content-Length: 51
+Content-Length: 40
 
-{"bookShelfId":1,"bookId":1,"readingStatus":"WISH"}</code></pre>
+{"bookShelfId":1,"readingStatus":"WISH"}</code></pre>
 </div>
 </div>
 <hr>
@@ -2619,7 +2614,7 @@ Content-Length: 51
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelf/books/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelves/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 51
@@ -2672,7 +2667,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /v1/api/bookshelf/books/{bookId}</caption>
+<caption class="title">Table 1. /v1/api/bookshelves/{bookShelfId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2685,8 +2680,8 @@ X-Frame-Options: DENY</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Book Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
 </tr>
 </tbody>
 </table>
@@ -2726,7 +2721,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelf/books/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelves/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 52
@@ -2779,7 +2774,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 2. /v1/api/bookshelf/books/{bookId}</caption>
+<caption class="title">Table 2. /v1/api/bookshelves/{bookShelfId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2792,8 +2787,8 @@ X-Frame-Options: DENY</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Book Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
 </tr>
 </tbody>
 </table>
@@ -2833,7 +2828,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelf/books/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelves/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 60
@@ -2886,7 +2881,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 3. /v1/api/bookshelf/books/{bookId}</caption>
+<caption class="title">Table 3. /v1/api/bookshelves/{bookShelfId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2899,8 +2894,8 @@ X-Frame-Options: DENY</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Book Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
 </tr>
 </tbody>
 </table>
@@ -2940,7 +2935,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelf/books/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelves/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 60
@@ -2993,7 +2988,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 4. /v1/api/bookshelf/books/{bookId}</caption>
+<caption class="title">Table 4. /v1/api/bookshelves/{bookShelfId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3006,14 +3001,14 @@ X-Frame-Options: DENY</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Book Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
 </tr>
 </tbody>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /v1/api/bookshelf/books/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /v1/api/bookshelves/1 HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -3066,7 +3061,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 5. /v1/api/books/{bookId}/report</caption>
+<caption class="title">Table 5. /v1/api/bookshelves/{bookShelfId}/report</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3079,8 +3074,8 @@ X-Frame-Options: DENY</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Book Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
 </tr>
 </tbody>
 </table>
@@ -3114,7 +3109,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/books/1/report HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelves/1/report HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 112
@@ -3167,7 +3162,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 6. /v1/api/books/{bookId}/report</caption>
+<caption class="title">Table 6. /v1/api/bookshelves/{bookShelfId}/report</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3180,14 +3175,14 @@ X-Frame-Options: DENY</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Book Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
 </tr>
 </tbody>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/books/1/report HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelves/1/report HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -3271,7 +3266,7 @@ Content-Length: 116
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 7. /v1/api/books/{bookId}/report</caption>
+<caption class="title">Table 7. /v1/api/bookshelves/{bookShelfId}/report</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3284,14 +3279,14 @@ Content-Length: 116
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Book Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
 </tr>
 </tbody>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /v1/api/books/1/report HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /v1/api/bookshelves/1/report HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -3340,7 +3335,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 8. /v1/api/books/{bookId}/report</caption>
+<caption class="title">Table 8. /v1/api/bookshelves/{bookShelfId}/report</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3353,8 +3348,8 @@ X-Frame-Options: DENY</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Book Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookShelfId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BookShelf Id</p></td>
 </tr>
 </tbody>
 </table>
@@ -3388,7 +3383,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/books/1/report HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelves/1/report HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 251
@@ -3445,7 +3440,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 9. /v1/api/bookshelf/{bookShelfId}/agonies</caption>
+<caption class="title">Table 9. /v1/api/bookshelves/{bookShelfId}/agonies</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3493,7 +3488,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelf/1/agonies HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelves/1/agonies HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 42
@@ -3546,7 +3541,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 10. /v1/api/bookshelf/{bookShelfId}/agonies</caption>
+<caption class="title">Table 10. /v1/api/bookshelves/{bookShelfId}/agonies</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3595,7 +3590,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelf/1/agonies?size=2&amp;sort=id,DESC&amp;postCursorId=1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelves/1/agonies?size=2&amp;sort=id,DESC&amp;postCursorId=1 HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -3682,7 +3677,7 @@ Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
 Content-Length: 256
 
-{"agonyResponseList":[{"agonyId":1,"title":"고민1","hexColorCode":"빨강"},{"agonyId":2,"title":"고민2","hexColorCode":"파랑"}],"cursorMeta":{"sliceSize":2,"contentSize":2,"hasContent":true,"hasNext":true,"nextCursorId":2,"last":false,"first":true}}</code></pre>
+{"agonyResponseList":[{"agonyId":1,"title":"고민1","hexColorCode":"빨강"},{"agonyId":2,"title":"고민2","hexColorCode":"파랑"}],"cursorMeta":{"sliceSize":2,"contentSize":2,"hasContent":true,"hasNext":true,"nextCursorId":2,"first":true,"last":false}}</code></pre>
 </div>
 </div>
 <hr>
@@ -3714,7 +3709,7 @@ Content-Length: 256
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 11. /v1/api/bookshelf/{bookShelfId}/agonies/{agoniesIds}</caption>
+<caption class="title">Table 11. /v1/api/bookshelves/{bookShelfId}/agonies/{agoniesIds}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3738,7 +3733,7 @@ Content-Length: 256
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /v1/api/bookshelf/1/agonies/1,2,3 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /v1/api/bookshelves/1/agonies/1,2,3 HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -3787,7 +3782,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 12. /v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}</caption>
+<caption class="title">Table 12. /v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3839,7 +3834,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelf/1/agonies/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelves/1/agonies/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 55
@@ -3896,7 +3891,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 13. /v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records</caption>
+<caption class="title">Table 13. /v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}/records</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3948,7 +3943,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelf/1/agonies/1/records HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /v1/api/bookshelves/1/agonies/1/records HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 36
@@ -4001,7 +3996,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 14. /v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records</caption>
+<caption class="title">Table 14. /v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}/records</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -4054,7 +4049,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelf/1/agonies/1/records?postCursorId=1&amp;size=2&amp;sort=id,ASC HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /v1/api/bookshelves/1/agonies/1/records?postCursorId=1&amp;size=2&amp;sort=id,ASC HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -4146,7 +4141,7 @@ Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
 Content-Length: 360
 
-{"agonyRecordResponseList":[{"agonyRecordId":2,"agonyRecordTitle":"title1","agonyRecordContent":"content1","createdAt":"2023-02-06"},{"agonyRecordId":3,"agonyRecordTitle":"title2","agonyRecordContent":"content2","createdAt":"2023-02-06"}],"cursorMeta":{"sliceSize":2,"contentSize":2,"hasContent":true,"hasNext":false,"nextCursorId":3,"last":true,"first":true}}</code></pre>
+{"agonyRecordResponseList":[{"agonyRecordId":2,"agonyRecordTitle":"title1","agonyRecordContent":"content1","createdAt":"2023-02-06"},{"agonyRecordId":3,"agonyRecordTitle":"title2","agonyRecordContent":"content2","createdAt":"2023-02-06"}],"cursorMeta":{"sliceSize":2,"contentSize":2,"hasContent":true,"hasNext":false,"nextCursorId":3,"first":true,"last":true}}</code></pre>
 </div>
 </div>
 </div>
@@ -4177,7 +4172,7 @@ Content-Length: 360
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 15. /v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records/{recordId}</caption>
+<caption class="title">Table 15. /v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}/records/{recordId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -4205,7 +4200,7 @@ Content-Length: 360
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /v1/api/bookshelf/1/agonies/1/records/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /v1/api/bookshelves/1/agonies/1/records/1 HTTP/1.1
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Host: bookchat.link</code></pre>
 </div>
@@ -4254,7 +4249,7 @@ X-Frame-Options: DENY</code></pre>
 <p><code>Request</code></p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 16. /v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records/{recordId}</caption>
+<caption class="title">Table 16. /v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}/records/{recordId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -4310,7 +4305,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelf/1/agonies/1/records/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /v1/api/bookshelves/1/agonies/1/records/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwicHJvdmlkZXIiOiJnb29nbGUiLCJuYW1lIjoiZ29vZ2xlMTIzIiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSJ9.LKub56oLOIJFlTzNiwxqH0V4SubOOBiIZESje9yJDco
 Content-Length: 97
@@ -4666,7 +4661,7 @@ Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
 Content-Length: 865
 
-{"chatRoomResponseList":[{"roomId":1,"roomName":"이펙티브 자바 부수는 방","roomSid":"secret1","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":1,"lastActiveTime":"2023-02-06T13:50:28.8825137","lastChatContent":"안녕"},{"roomId":2,"roomName":"이펙티브 코틀린 부수는 방","roomSid":"secret2","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":2,"lastActiveTime":"2023-02-06T13:50:28.8825137","lastChatContent":"잘가"},{"roomId":3,"roomName":"토비의 스프링 부수는 방","roomSid":"secret3","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":3,"lastActiveTime":"2023-02-06T13:50:28.8825137","lastChatContent":"이거 모르겠음"}],"cursorMeta":{"sliceSize":3,"contentSize":3,"hasContent":true,"hasNext":true,"nextCursorId":3,"last":false,"first":true}}</code></pre>
+{"chatRoomResponseList":[{"roomId":1,"roomName":"이펙티브 자바 부수는 방","roomSid":"secret1","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":1,"lastActiveTime":"2023-02-06T15:49:49.9315838","lastChatContent":"안녕"},{"roomId":2,"roomName":"이펙티브 코틀린 부수는 방","roomSid":"secret2","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":2,"lastActiveTime":"2023-02-06T15:49:49.9315838","lastChatContent":"잘가"},{"roomId":3,"roomName":"토비의 스프링 부수는 방","roomSid":"secret3","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":3,"lastActiveTime":"2023-02-06T15:49:49.9315838","lastChatContent":"이거 모르겠음"}],"cursorMeta":{"sliceSize":3,"contentSize":3,"hasContent":true,"hasNext":true,"nextCursorId":3,"first":true,"last":false}}</code></pre>
 </div>
 </div>
 </div>

--- a/src/docs/asciidoc/index.html
+++ b/src/docs/asciidoc/index.html
@@ -605,7 +605,7 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 419
 Host: bookchat.link
 
-{"refreshToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY3OTAyNTksInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.oql8yeOathmAD1eaVF0wIoyW8L2TCkhwjSblyankhbY"}</code></pre>
+{"refreshToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY4MDM5NjIsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.Yzo49FxfRy1BC_McVUAh84Zz6kyQU_6OR1OH3Qu58tg"}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -650,7 +650,7 @@ Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
 Content-Length: 836
 
-{"accessToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzU1ODIwNTksInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.ZctVc8uR3EBt100AH9tBxjwDSoWnuXMVu_h4qt7Er6U","refreshToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY3OTAyNTksInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.oql8yeOathmAD1eaVF0wIoyW8L2TCkhwjSblyankhbY"}</code></pre>
+{"accessToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzU1OTU3NjIsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.tNXQYDGPbBWBa6M4uBWcSqH30HADtcb0ae2WxT-F-mQ","refreshToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJCb29rQ2hhdCIsImRlZmF1bHRQcm9maWxlSW1hZ2VUeXBlIjoxLCJwcm92aWRlciI6Imtha2FvIiwidXNlck5pY2tuYW1lIjoidGVzdFVzZXJOaWNrbmFtZSIsInVzZXJOYW1lIjoidGVzdFVzZXIiLCJ1c2VyUHJvZmlsZUltYWdlVXJpIjoic29tZXRoaW5nSW1hZ2VVcmxAbmF2ZXIuY29tIiwidXNlclJvbGUiOiJST0xFX1VTRVIiLCJleHAiOjE2NzY4MDM5NjIsInVzZXJJZCI6IjEiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIn0.Yzo49FxfRy1BC_McVUAh84Zz6kyQU_6OR1OH3Qu58tg"}</code></pre>
 </div>
 </div>
 </div>
@@ -1970,7 +1970,7 @@ X-Frame-Options: DENY</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>sort</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>false</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">등록순-id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">등록순-id | 변경순-updatedAt</p></td>
 </tr>
 </tbody>
 </table>
@@ -2148,7 +2148,7 @@ Host: bookchat.link</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>sort</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>false</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">등록순-id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">등록순-id | 변경순-updatedAt</p></td>
 </tr>
 </tbody>
 </table>
@@ -2326,7 +2326,7 @@ Host: bookchat.link</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>sort</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>false</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">등록순-id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">등록순-id | 변경순-updatedAt</p></td>
 </tr>
 </tbody>
 </table>
@@ -4602,9 +4602,9 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
-Content-Length: 862
+Content-Length: 861
 
-{"chatRoomResponseList":[{"roomId":1,"roomName":"이펙티브 자바 부수는 방","roomSid":"secret1","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":1,"lastActiveTime":"2023-02-05T15:57:31.153242","lastChatContent":"안녕"},{"roomId":2,"roomName":"이펙티브 코틀린 부수는 방","roomSid":"secret2","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":2,"lastActiveTime":"2023-02-05T15:57:31.153258","lastChatContent":"잘가"},{"roomId":3,"roomName":"토비의 스프링 부수는 방","roomSid":"secret3","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":3,"lastActiveTime":"2023-02-05T15:57:31.153279","lastChatContent":"이거 모르겠음"}],"cursorMeta":{"sliceSize":3,"contentSize":3,"hasContent":true,"hasNext":true,"nextCursorId":3,"first":true,"last":false}}</code></pre>
+{"chatRoomResponseList":[{"roomId":1,"roomName":"이펙티브 자바 부수는 방","roomSid":"secret1","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":1,"lastActiveTime":"2023-02-05T19:45:55.852575","lastChatContent":"안녕"},{"roomId":2,"roomName":"이펙티브 코틀린 부수는 방","roomSid":"secret2","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":2,"lastActiveTime":"2023-02-05T19:45:55.85259","lastChatContent":"잘가"},{"roomId":3,"roomName":"토비의 스프링 부수는 방","roomSid":"secret3","roomMemberCount":2,"defaultRoomImageType":1,"roomImageUri":null,"lastChatId":3,"lastActiveTime":"2023-02-05T19:45:55.852603","lastChatContent":"이거 모르겠음"}],"cursorMeta":{"sliceSize":3,"contentSize":3,"hasContent":true,"hasNext":true,"nextCursorId":3,"first":true,"last":false}}</code></pre>
 </div>
 </div>
 </div>

--- a/src/main/java/toy/bookchat/bookchat/BookChatApplication.java
+++ b/src/main/java/toy/bookchat/bookchat/BookChatApplication.java
@@ -16,5 +16,4 @@ public class BookChatApplication {
     public static void main(String[] args) {
         SpringApplication.run(BookChatApplication.class, args);
     }
-
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/agony/Agony.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/agony/Agony.java
@@ -10,7 +10,6 @@ import lombok.Builder;
 import lombok.Getter;
 import toy.bookchat.bookchat.domain.BaseEntity;
 import toy.bookchat.bookchat.domain.bookshelf.BookShelf;
-import toy.bookchat.bookchat.domain.user.User;
 
 @Getter
 @Entity
@@ -23,16 +22,13 @@ public class Agony extends BaseEntity {
     private String hexColorCode;
     @ManyToOne(fetch = FetchType.LAZY)
     private BookShelf bookShelf;
-    @ManyToOne(fetch = FetchType.LAZY)
-    private User user;
 
     @Builder
-    private Agony(Long id, String title, String hexColorCode, BookShelf bookShelf, User user) {
+    private Agony(Long id, String title, String hexColorCode, BookShelf bookShelf) {
         this.id = id;
         this.title = title;
         this.hexColorCode = hexColorCode;
         this.bookShelf = bookShelf;
-        this.user = user;
     }
 
     protected Agony() {

--- a/src/main/java/toy/bookchat/bookchat/domain/agony/api/AgonyController.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/agony/api/AgonyController.java
@@ -37,27 +37,28 @@ public class AgonyController {
             bookShelfId);
     }
 
-    @GetMapping("/v1/api/agonies")
-    public SliceOfAgoniesResponse searchSliceOfAgonies(
+    @GetMapping("/v1/api/bookshelf/{bookShelfId}/agonies")
+    public SliceOfAgoniesResponse searchSliceOfAgonies(@PathVariable Long bookShelfId,
         @RequestParam Optional<Long> postCursorId, Pageable pageable,
         @UserPayload TokenPayload tokenPayload) {
 
-        return agonyService.searchSliceOfAgonies(tokenPayload.getUserId(), pageable,
+        return agonyService.searchSliceOfAgonies(bookShelfId, tokenPayload.getUserId(), pageable,
             postCursorId);
     }
 
-    @DeleteMapping("/v1/api/agonies/{agoniesIds}")
-    public void deleteAgony(@PathVariable List<Long> agoniesIds,
+    @DeleteMapping("/v1/api/bookshelf/{bookShelfId}/agonies/{agoniesIds}")
+    public void deleteAgony(@PathVariable Long bookShelfId, @PathVariable List<Long> agoniesIds,
         @UserPayload TokenPayload tokenPayload) {
 
-        agonyService.deleteAgony(agoniesIds, tokenPayload.getUserId());
+        agonyService.deleteAgony(bookShelfId, agoniesIds, tokenPayload.getUserId());
     }
 
-    @PutMapping("/v1/api/agonies/{agonyId}")
-    public void reviseAgony(@PathVariable Long agonyId,
+    @PutMapping("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}")
+    public void reviseAgony(@PathVariable Long bookShelfId, @PathVariable Long agonyId,
         @Valid @RequestBody ReviseAgonyRequest reviseAgonyRequest,
         @UserPayload TokenPayload tokenPayload) {
 
-        agonyService.reviseAgony(agonyId, tokenPayload.getUserId(), reviseAgonyRequest);
+        agonyService.reviseAgony(bookShelfId, agonyId, tokenPayload.getUserId(),
+            reviseAgonyRequest);
     }
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/agony/api/AgonyController.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/agony/api/AgonyController.java
@@ -28,7 +28,7 @@ public class AgonyController {
         this.agonyService = agonyService;
     }
 
-    @PostMapping("/v1/api/bookshelf/{bookShelfId}/agonies")
+    @PostMapping("/v1/api/bookshelves/{bookShelfId}/agonies")
     public void makeBookAgony(@PathVariable Long bookShelfId,
         @Valid @RequestBody CreateBookAgonyRequest createBookAgonyRequest,
         @UserPayload TokenPayload tokenPayload) {
@@ -37,7 +37,7 @@ public class AgonyController {
             bookShelfId);
     }
 
-    @GetMapping("/v1/api/bookshelf/{bookShelfId}/agonies")
+    @GetMapping("/v1/api/bookshelves/{bookShelfId}/agonies")
     public SliceOfAgoniesResponse searchSliceOfAgonies(@PathVariable Long bookShelfId,
         @RequestParam Optional<Long> postCursorId, Pageable pageable,
         @UserPayload TokenPayload tokenPayload) {
@@ -46,14 +46,14 @@ public class AgonyController {
             postCursorId);
     }
 
-    @DeleteMapping("/v1/api/bookshelf/{bookShelfId}/agonies/{agoniesIds}")
+    @DeleteMapping("/v1/api/bookshelves/{bookShelfId}/agonies/{agoniesIds}")
     public void deleteAgony(@PathVariable Long bookShelfId, @PathVariable List<Long> agoniesIds,
         @UserPayload TokenPayload tokenPayload) {
 
         agonyService.deleteAgony(bookShelfId, agoniesIds, tokenPayload.getUserId());
     }
 
-    @PutMapping("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}")
+    @PutMapping("/v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}")
     public void reviseAgony(@PathVariable Long bookShelfId, @PathVariable Long agonyId,
         @Valid @RequestBody ReviseAgonyRequest reviseAgonyRequest,
         @UserPayload TokenPayload tokenPayload) {

--- a/src/main/java/toy/bookchat/bookchat/domain/agony/api/AgonyController.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/agony/api/AgonyController.java
@@ -28,12 +28,13 @@ public class AgonyController {
         this.agonyService = agonyService;
     }
 
-    @PostMapping("/v1/api/bookshelf/books/{bookId}/agonies")
-    public void makeBookAgony(@PathVariable Long bookId,
+    @PostMapping("/v1/api/bookshelf/{bookShelfId}/agonies")
+    public void makeBookAgony(@PathVariable Long bookShelfId,
         @Valid @RequestBody CreateBookAgonyRequest createBookAgonyRequest,
         @UserPayload TokenPayload tokenPayload) {
 
-        agonyService.storeBookAgony(createBookAgonyRequest, tokenPayload.getUserId(), bookId);
+        agonyService.storeBookShelfAgony(createBookAgonyRequest, tokenPayload.getUserId(),
+            bookShelfId);
     }
 
     @GetMapping("/v1/api/agonies")

--- a/src/main/java/toy/bookchat/bookchat/domain/agony/repository/query/AgonyQueryRepository.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/agony/repository/query/AgonyQueryRepository.java
@@ -8,12 +8,12 @@ import toy.bookchat.bookchat.domain.agony.Agony;
 
 public interface AgonyQueryRepository {
 
-    Optional<Agony> findUserBookShelfAgony(Long userId, Long agonyId);
+    Optional<Agony> findUserBookShelfAgony(Long bookShelfId, Long agonyId, Long userId);
 
-    Slice<Agony> findUserBookShelfSliceOfAgonies(long userId, Pageable pageable,
+    Slice<Agony> findUserBookShelfSliceOfAgonies(Long bookShelfId, Long userId, Pageable pageable,
         Optional<Long> postCursorId);
 
-    void deleteByAgoniesIds(Long userId, List<Long> agoniesIds);
+    void deleteByAgoniesIds(Long bookShelfId, Long userId, List<Long> agoniesIds);
 
     void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/agony/repository/query/AgonyQueryRepositoryImpl.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/agony/repository/query/AgonyQueryRepositoryImpl.java
@@ -1,10 +1,10 @@
 package toy.bookchat.bookchat.domain.agony.repository.query;
 
 import static toy.bookchat.bookchat.domain.agony.QAgony.agony;
+import static toy.bookchat.bookchat.domain.bookshelf.QBookShelf.bookShelf;
 import static toy.bookchat.bookchat.domain.common.RepositorySupport.extractOrderSpecifierFrom;
 import static toy.bookchat.bookchat.domain.common.RepositorySupport.numberBasedPagination;
 import static toy.bookchat.bookchat.domain.common.RepositorySupport.toSlice;
-import static toy.bookchat.bookchat.domain.user.QUser.user;
 
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -14,7 +14,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 import toy.bookchat.bookchat.domain.agony.Agony;
-import toy.bookchat.bookchat.domain.agony.QAgony;
 
 @Repository
 public class AgonyQueryRepositoryImpl implements AgonyQueryRepository {
@@ -26,20 +25,24 @@ public class AgonyQueryRepositoryImpl implements AgonyQueryRepository {
     }
 
     @Override
-    public Optional<Agony> findUserBookShelfAgony(Long userId, Long agonyId) {
+    public Optional<Agony> findUserBookShelfAgony(Long bookShelfId, Long agonyId, Long userId) {
         return Optional.ofNullable(queryFactory.select(agony)
             .from(agony)
-            .join(agony.user, user).on(user.id.eq(userId))
+            .join(agony.bookShelf, bookShelf)
+            .on(bookShelf.id.eq(bookShelfId)
+                .and(bookShelf.user.id.eq(userId)))
             .where(agony.id.eq(agonyId))
             .fetchOne());
     }
 
     @Override
-    public Slice<Agony> findUserBookShelfSliceOfAgonies(long userId, Pageable pageable,
+    public Slice<Agony> findUserBookShelfSliceOfAgonies(Long bookShelfId, Long userId,
+        Pageable pageable,
         Optional<Long> postCursorId) {
         List<Agony> contents = queryFactory.select(agony)
             .from(agony)
-            .join(agony.user, user).on(user.id.eq(userId))
+            .join(agony.bookShelf, bookShelf)
+            .on(bookShelf.id.eq(bookShelfId).and(bookShelf.user.id.eq(userId)))
             .where(numberBasedPagination(agony, agony.id, postCursorId, pageable))
             .limit(pageable.getPageSize())
             .orderBy(extractOrderSpecifierFrom(agony, pageable))
@@ -48,24 +51,24 @@ public class AgonyQueryRepositoryImpl implements AgonyQueryRepository {
         return toSlice(contents, pageable);
     }
 
-
     @Override
-    public void deleteByAgoniesIds(Long userId, List<Long> agoniesIds) {
-        QAgony subAgony = new QAgony("subAgony");
-
+    public void deleteByAgoniesIds(Long bookShelfId, Long userId, List<Long> agoniesIds) {
         queryFactory.delete(agony)
-            .where(agony.id.in(
-                JPAExpressions.select(subAgony.id)
-                    .from(subAgony)
-                    .join(subAgony.user, user)
-                    .on(user.id.eq(userId))
-                    .where(subAgony.id.in(agoniesIds))
-            )).execute();
+            .where(agony.bookShelf.id.in(
+                    JPAExpressions.select(bookShelf.id)
+                        .from(bookShelf)
+                        .where(bookShelf.user.id.eq(userId))),
+                agony.id.in(agoniesIds)
+            ).execute();
     }
 
     @Override
     public void deleteAllByUserId(Long userId) {
         queryFactory.delete(agony)
-            .where(agony.user.id.eq(userId)).execute();
+            .where(agony.bookShelf.id.in(
+                JPAExpressions.select(bookShelf.id)
+                    .from(bookShelf)
+                    .where(bookShelf.user.id.eq(userId))
+            )).execute();
     }
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/agony/service/AgonyService.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/agony/service/AgonyService.java
@@ -42,23 +42,23 @@ public class AgonyService {
     }
 
     @Transactional(readOnly = true)
-    public SliceOfAgoniesResponse searchSliceOfAgonies(Long userId,
+    public SliceOfAgoniesResponse searchSliceOfAgonies(Long bookShelfId, Long userId,
         Pageable pageable, Optional<Long> postCursorId) {
         return new SliceOfAgoniesResponse(
-            agonyRepository.findUserBookShelfSliceOfAgonies(userId, pageable,
+            agonyRepository.findUserBookShelfSliceOfAgonies(bookShelfId, userId, pageable,
                 postCursorId));
     }
 
     @Transactional
-    public void deleteAgony(List<Long> agoniesIds, Long userId) {
-        agonyRecordRepository.deleteByAgoniesIds(userId, agoniesIds);
-        agonyRepository.deleteByAgoniesIds(userId, agoniesIds);
+    public void deleteAgony(Long bookShelfId, List<Long> agoniesIds, Long userId) {
+        agonyRecordRepository.deleteByAgoniesIds(bookShelfId, userId, agoniesIds);
+        agonyRepository.deleteByAgoniesIds(bookShelfId, userId, agoniesIds);
     }
 
     @Transactional
-    public void reviseAgony(Long agonyId, Long userId,
+    public void reviseAgony(Long bookShelfId, Long agonyId, Long userId,
         ReviseAgonyRequest reviseAgonyRequest) {
-        Agony agony = agonyRepository.findUserBookShelfAgony(userId, agonyId)
+        Agony agony = agonyRepository.findUserBookShelfAgony(bookShelfId, agonyId, userId)
             .orElseThrow(AgonyNotFoundException::new);
         agony.changeTitle(reviseAgonyRequest.getTitle());
         agony.changeHexColorCode(reviseAgonyRequest.getHexColorCode());

--- a/src/main/java/toy/bookchat/bookchat/domain/agony/service/AgonyService.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/agony/service/AgonyService.java
@@ -33,10 +33,9 @@ public class AgonyService {
     }
 
     @Transactional
-    public void storeBookAgony(CreateBookAgonyRequest createBookAgonyRequest, Long userId,
-        Long bookId) {
-
-        BookShelf bookShelf = bookShelfRepository.findByUserIdAndBookId(userId, bookId)
+    public void storeBookShelfAgony(CreateBookAgonyRequest createBookAgonyRequest, Long userId,
+        Long bookShelfId) {
+        BookShelf bookShelf = bookShelfRepository.findByIdAndUserId(bookShelfId, userId)
             .orElseThrow(BookNotFoundException::new);
 
         agonyRepository.save(createBookAgonyRequest.getAgony(bookShelf));

--- a/src/main/java/toy/bookchat/bookchat/domain/agony/service/dto/request/CreateBookAgonyRequest.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/agony/service/dto/request/CreateBookAgonyRequest.java
@@ -21,7 +21,6 @@ public class CreateBookAgonyRequest {
             .title(this.title)
             .hexColorCode(this.hexColorCode)
             .bookShelf(bookShelf)
-            .user(bookShelf.getUser())
             .build();
     }
 

--- a/src/main/java/toy/bookchat/bookchat/domain/agonyrecord/api/AgonyRecordController.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/agonyrecord/api/AgonyRecordController.java
@@ -28,37 +28,45 @@ public class AgonyRecordController {
         this.agonyRecordService = agonyRecordService;
     }
 
-    @PostMapping("/v1/api/agonies/{agonyId}/records")
-    public void addAgonyRecordOnBookAgony(@PathVariable Long agonyId,
+    @PostMapping("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records")
+    public void addAgonyRecordOnBookAgony(@PathVariable Long bookShelfId,
+        @PathVariable Long agonyId,
         @Valid @RequestBody CreateAgonyRecordRequest createAgonyRecordRequest,
         @UserPayload TokenPayload tokenPayload) {
 
-        agonyRecordService.storeAgonyRecord(createAgonyRecordRequest, tokenPayload.getUserId(),
+        agonyRecordService.storeAgonyRecord(bookShelfId, createAgonyRecordRequest,
+            tokenPayload.getUserId(),
             agonyId);
     }
 
-    @GetMapping("/v1/api/agonies/{agonyId}/records")
-    public SliceOfAgonyRecordsResponse getAgonyRecordsOnBookAgony(@PathVariable Long agonyId,
+    @GetMapping("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records")
+    public SliceOfAgonyRecordsResponse getAgonyRecordsOnBookAgony(@PathVariable Long bookShelfId,
+        @PathVariable Long agonyId,
         @RequestParam Optional<Long> postCursorId,
         @UserPayload TokenPayload tokenPayload, Pageable pageable) {
 
-        return agonyRecordService.searchPageOfAgonyRecords(agonyId, tokenPayload.getUserId(),
+        return agonyRecordService.searchPageOfAgonyRecords(bookShelfId, agonyId,
+            tokenPayload.getUserId(),
             pageable, postCursorId);
     }
 
-    @DeleteMapping("/v1/api/agonies/{agonyId}/records/{recordId}")
-    public void deleteAgonyRecord(@PathVariable Long agonyId, @PathVariable Long recordId,
+    @DeleteMapping("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records/{recordId}")
+    public void deleteAgonyRecord(@PathVariable Long bookShelfId, @PathVariable Long agonyId,
+        @PathVariable Long recordId,
         @UserPayload TokenPayload tokenPayload) {
 
-        agonyRecordService.deleteAgonyRecord(agonyId, recordId, tokenPayload.getUserId());
+        agonyRecordService.deleteAgonyRecord(bookShelfId, agonyId, recordId,
+            tokenPayload.getUserId());
     }
 
-    @PutMapping("/v1/api/agonies/{agonyId}/records/{recordId}")
-    public void reviseAgonyRecord(@PathVariable Long agonyId, @PathVariable Long recordId,
+    @PutMapping("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records/{recordId}")
+    public void reviseAgonyRecord(@PathVariable Long bookShelfId, @PathVariable Long agonyId,
+        @PathVariable Long recordId,
         @Valid @RequestBody ReviseAgonyRecordRequest reviseAgonyRecordRequest,
         @UserPayload TokenPayload tokenPayload) {
 
-        agonyRecordService.reviseAgonyRecord(agonyId, recordId, tokenPayload.getUserId(),
+        agonyRecordService.reviseAgonyRecord(bookShelfId, agonyId, recordId,
+            tokenPayload.getUserId(),
             reviseAgonyRecordRequest);
     }
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/agonyrecord/api/AgonyRecordController.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/agonyrecord/api/AgonyRecordController.java
@@ -28,7 +28,7 @@ public class AgonyRecordController {
         this.agonyRecordService = agonyRecordService;
     }
 
-    @PostMapping("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records")
+    @PostMapping("/v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}/records")
     public void addAgonyRecordOnBookAgony(@PathVariable Long bookShelfId,
         @PathVariable Long agonyId,
         @Valid @RequestBody CreateAgonyRecordRequest createAgonyRecordRequest,
@@ -39,7 +39,7 @@ public class AgonyRecordController {
             agonyId);
     }
 
-    @GetMapping("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records")
+    @GetMapping("/v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}/records")
     public SliceOfAgonyRecordsResponse getAgonyRecordsOnBookAgony(@PathVariable Long bookShelfId,
         @PathVariable Long agonyId,
         @RequestParam Optional<Long> postCursorId,
@@ -50,7 +50,7 @@ public class AgonyRecordController {
             pageable, postCursorId);
     }
 
-    @DeleteMapping("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records/{recordId}")
+    @DeleteMapping("/v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}/records/{recordId}")
     public void deleteAgonyRecord(@PathVariable Long bookShelfId, @PathVariable Long agonyId,
         @PathVariable Long recordId,
         @UserPayload TokenPayload tokenPayload) {
@@ -59,7 +59,7 @@ public class AgonyRecordController {
             tokenPayload.getUserId());
     }
 
-    @PutMapping("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records/{recordId}")
+    @PutMapping("/v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}/records/{recordId}")
     public void reviseAgonyRecord(@PathVariable Long bookShelfId, @PathVariable Long agonyId,
         @PathVariable Long recordId,
         @Valid @RequestBody ReviseAgonyRecordRequest reviseAgonyRecordRequest,

--- a/src/main/java/toy/bookchat/bookchat/domain/agonyrecord/repository/query/AgonyRecordQueryRepository.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/agonyrecord/repository/query/AgonyRecordQueryRepository.java
@@ -8,15 +8,15 @@ import toy.bookchat.bookchat.domain.agonyrecord.AgonyRecord;
 
 public interface AgonyRecordQueryRepository {
 
-    Slice<AgonyRecord> findSliceOfUserAgonyRecords(Long agonyId, Long userId,
+    Slice<AgonyRecord> findSliceOfUserAgonyRecords(Long bookShelfId, Long agonyId, Long userId,
         Pageable pageable, Optional<Long> postCursorId);
 
-    void deleteAgony(Long userId, Long agonyId, Long recordId);
+    void deleteAgonyRecord(Long bookShelfId, Long agonyId, Long recordId, Long userId);
 
-    void reviseAgonyRecord(Long userId, Long agonyId, Long recordId,
+    void reviseAgonyRecord(Long bookShelfId, Long agonyId, Long recordId, Long userId,
         String recordTitle, String recordContent);
 
-    void deleteByAgoniesIds(Long userId, List<Long> agoniesIds);
+    void deleteByAgoniesIds(Long bookShelfId, Long userId, List<Long> agoniesIds);
 
     void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/agonyrecord/service/AgonyRecordService.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/agonyrecord/service/AgonyRecordService.java
@@ -27,30 +27,31 @@ public class AgonyRecordService {
     }
 
     @Transactional
-    public void storeAgonyRecord(CreateAgonyRecordRequest createAgonyRecordRequest,
+    public void storeAgonyRecord(Long bookShelfId,
+        CreateAgonyRecordRequest createAgonyRecordRequest,
         Long userId, Long agonyId) {
-        Agony agony = agonyRepository.findUserBookShelfAgony(userId, agonyId)
+        Agony agony = agonyRepository.findUserBookShelfAgony(bookShelfId, agonyId, userId)
             .orElseThrow(AgonyNotFoundException::new);
         agonyRecordRepository.save(createAgonyRecordRequest.generateAgonyRecord(agony));
     }
 
     @Transactional(readOnly = true)
-    public SliceOfAgonyRecordsResponse searchPageOfAgonyRecords(Long agonyId,
+    public SliceOfAgonyRecordsResponse searchPageOfAgonyRecords(Long bookShelfId, Long agonyId,
         Long userId, Pageable pageable, Optional<Long> postCursorId) {
         Slice<AgonyRecord> agonyRecordSlice = agonyRecordRepository.findSliceOfUserAgonyRecords(
-            agonyId, userId, pageable, postCursorId);
+            bookShelfId, agonyId, userId, pageable, postCursorId);
         return new SliceOfAgonyRecordsResponse(agonyRecordSlice);
     }
 
     @Transactional
-    public void deleteAgonyRecord(Long agonyId, Long recordId, Long userId) {
-        agonyRecordRepository.deleteAgony(userId, agonyId, recordId);
+    public void deleteAgonyRecord(Long bookShelfId, Long agonyId, Long recordId, Long userId) {
+        agonyRecordRepository.deleteAgonyRecord(bookShelfId, agonyId, recordId, userId);
     }
 
     @Transactional
-    public void reviseAgonyRecord(Long agonyId, Long recordId, Long userId,
+    public void reviseAgonyRecord(Long bookShelfId, Long agonyId, Long recordId, Long userId,
         ReviseAgonyRecordRequest reviseAgonyRecordRequest) {
-        agonyRecordRepository.reviseAgonyRecord(userId, agonyId, recordId,
+        agonyRecordRepository.reviseAgonyRecord(bookShelfId, agonyId, recordId, userId,
             reviseAgonyRecordRequest.getRecordTitle(), reviseAgonyRecordRequest.getRecordContent());
     }
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/bookreport/api/BookReportController.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookreport/api/BookReportController.java
@@ -17,7 +17,7 @@ import toy.bookchat.bookchat.security.user.TokenPayload;
 import toy.bookchat.bookchat.security.user.UserPayload;
 
 @RestController
-@RequestMapping("/v1/api/books/{bookId}/report")
+@RequestMapping("/v1/api/bookshelves/{bookShelfId}/report")
 public class BookReportController {
 
     private final BookReportService bookReportService;
@@ -29,31 +29,32 @@ public class BookReportController {
     @PostMapping
     public void writeBookReport(
         @Valid @RequestBody WriteBookReportRequest writeBookReportRequest,
-        @PathVariable Long bookId, @UserPayload TokenPayload tokenPayload) {
+        @PathVariable Long bookShelfId, @UserPayload TokenPayload tokenPayload) {
 
-        bookReportService.writeReport(writeBookReportRequest, bookId, tokenPayload.getUserId());
+        bookReportService.writeReport(writeBookReportRequest, bookShelfId,
+            tokenPayload.getUserId());
     }
 
     @GetMapping
-    public BookReportResponse findBookReportFromBook(@PathVariable Long bookId,
+    public BookReportResponse findBookReportFromBook(@PathVariable Long bookShelfId,
         @UserPayload TokenPayload tokenPayload) {
 
-        return bookReportService.getBookReportResponse(bookId, tokenPayload.getUserId());
+        return bookReportService.getBookReportResponse(bookShelfId, tokenPayload.getUserId());
     }
 
     @DeleteMapping
-    public void deleteBookReport(@PathVariable Long bookId,
+    public void deleteBookReport(@PathVariable Long bookShelfId,
         @UserPayload TokenPayload tokenPayload) {
 
-        bookReportService.deleteBookReport(bookId, tokenPayload.getUserId());
+        bookReportService.deleteBookReport(bookShelfId, tokenPayload.getUserId());
     }
 
     @PutMapping
-    public void reviseBookReport(@PathVariable Long bookId,
+    public void reviseBookReport(@PathVariable Long bookShelfId,
         @Valid @RequestBody ReviseBookReportRequest reviseBookReportRequest,
         @UserPayload TokenPayload tokenPayload) {
 
-        bookReportService.reviseBookReport(bookId, tokenPayload.getUserId(),
+        bookReportService.reviseBookReport(bookShelfId, tokenPayload.getUserId(),
             reviseBookReportRequest);
     }
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/bookreport/service/BookReportService.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookreport/service/BookReportService.java
@@ -24,10 +24,10 @@ public class BookReportService {
     }
 
     @Transactional
-    public void writeReport(WriteBookReportRequest writeBookReportRequest, Long bookId,
+    public void writeReport(WriteBookReportRequest writeBookReportRequest, Long bookShelfId,
         Long userId) {
 
-        BookShelf bookShelf = bookShelfRepository.findByUserIdAndBookId(userId, bookId)
+        BookShelf bookShelf = bookShelfRepository.findByIdAndUserId(bookShelfId, userId)
             .orElseThrow(BookNotFoundException::new);
 
         BookReport bookReport = writeBookReportRequest.getBookReport(bookShelf);
@@ -36,24 +36,24 @@ public class BookReportService {
     }
 
     @Transactional(readOnly = true)
-    public BookReportResponse getBookReportResponse(Long bookId, Long userId) {
-        BookShelf bookShelf = bookShelfRepository.findByUserIdAndBookId(userId, bookId)
+    public BookReportResponse getBookReportResponse(Long bookShelfId, Long userId) {
+        BookShelf bookShelf = bookShelfRepository.findByIdAndUserId(bookShelfId, userId)
             .orElseThrow(BookNotFoundException::new);
 
         return BookReportResponse.from(bookShelf.getBookReport());
     }
 
     @Transactional
-    public void deleteBookReport(Long bookId, Long userId) {
-        BookShelf bookShelf = bookShelfRepository.findByUserIdAndBookId(userId, bookId)
+    public void deleteBookReport(Long bookShelfId, Long userId) {
+        BookShelf bookShelf = bookShelfRepository.findByIdAndUserId(bookShelfId, userId)
             .orElseThrow(BookNotFoundException::new);
 
         bookShelf.deleteBookReport();
     }
 
-    public void reviseBookReport(Long bookId, Long userId,
+    public void reviseBookReport(Long bookShelfId, Long userId,
         ReviseBookReportRequest reviseBookReportRequest) {
-        BookShelf bookShelf = bookShelfRepository.findByUserIdAndBookId(userId, bookId)
+        BookShelf bookShelf = bookShelfRepository.findByIdAndUserId(bookShelfId, userId)
             .orElseThrow(BookNotFoundException::new);
         BookReport bookReport = bookShelf.getBookReport();
 

--- a/src/main/java/toy/bookchat/bookchat/domain/bookreport/service/BookReportService.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookreport/service/BookReportService.java
@@ -51,9 +51,11 @@ public class BookReportService {
         bookShelf.deleteBookReport();
     }
 
+    @Transactional
     public void reviseBookReport(Long bookShelfId, Long userId,
         ReviseBookReportRequest reviseBookReportRequest) {
-        BookShelf bookShelf = bookShelfRepository.findByIdAndUserId(bookShelfId, userId)
+        BookShelf bookShelf = bookShelfRepository.findWithReportByIdAndUserId(bookShelfId,
+                userId)
             .orElseThrow(BookNotFoundException::new);
         BookReport bookReport = bookShelf.getBookReport();
 

--- a/src/main/java/toy/bookchat/bookchat/domain/bookshelf/api/BookShelfController.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookshelf/api/BookShelfController.java
@@ -31,42 +31,42 @@ public class BookShelfController {
         this.bookShelfService = bookShelfService;
     }
 
-    @PostMapping("/bookshelf/books")
+    @PostMapping("/bookshelves")
     public void putBookOnBookShelf(@RequestBody @Valid BookShelfRequest bookShelfRequest,
         @UserPayload TokenPayload tokenPayload) {
 
         bookShelfService.putBookOnBookShelf(bookShelfRequest, tokenPayload.getUserId());
     }
 
-    @GetMapping("/bookshelf/books")
-    public SearchBookShelfByReadingStatus takeBookOutOfBookShelf(ReadingStatus readingStatus,
+    @GetMapping("/bookshelves")
+    public SearchBookShelfByReadingStatus takeBooksOutOfBookShelves(ReadingStatus readingStatus,
         Pageable pageable, @UserPayload TokenPayload tokenPayload) {
-        return bookShelfService.takeBooksOutOfBookShelf(readingStatus, pageable,
+        return bookShelfService.takeBooksOutOfBookShelves(readingStatus, pageable,
             tokenPayload.getUserId());
     }
 
-    @GetMapping("/bookshelf/books/existence")
-    public ExistenceBookOnBookShelfResponse findBookIfExistedOnBookShelf(String isbn,
+    @GetMapping("/bookshelves/book")
+    public ExistenceBookOnBookShelfResponse findBookIfExistedOnBookShelves(String isbn,
         @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate publishAt,
         @UserPayload TokenPayload tokenPayload) {
 
         return bookShelfService.getBookIfExisted(isbn, publishAt, tokenPayload.getUserId());
     }
 
-    @PutMapping("/bookshelf/books/{bookId}")
-    public void reviseBookOnBookShelf(@PathVariable Long bookId,
+    @PutMapping("/bookshelves/{bookShelfId}")
+    public void reviseBookOnBookShelf(@PathVariable Long bookShelfId,
         @Valid @RequestBody ReviseBookShelfRequest reviseBookShelfStarRequest,
         @UserPayload TokenPayload tokenPayload) {
 
-        bookShelfService.reviseBookShelf(bookId, reviseBookShelfStarRequest,
+        bookShelfService.reviseBookShelf(bookShelfId, reviseBookShelfStarRequest,
             tokenPayload.getUserId());
     }
 
-    @DeleteMapping("/bookshelf/books/{bookId}")
-    public void deleteBookOnBookShelf(@PathVariable Long bookId,
+    @DeleteMapping("/bookshelves/{bookShelfId}")
+    public void deleteBookOnBookShelf(@PathVariable Long bookShelfId,
         @UserPayload TokenPayload tokenPayload) {
 
-        bookShelfService.deleteBookOnBookShelf(bookId, tokenPayload.getUserId());
+        bookShelfService.deleteBookShelf(bookShelfId, tokenPayload.getUserId());
     }
 
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/bookshelf/repository/query/BookShelfQueryRepository.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookshelf/repository/query/BookShelfQueryRepository.java
@@ -9,17 +9,16 @@ import toy.bookchat.bookchat.domain.bookshelf.ReadingStatus;
 
 public interface BookShelfQueryRepository {
 
-    Page<BookShelf> findSpecificStatusBookByUserId(
-        ReadingStatus readingStatus, Pageable pageable, Long userId);
-
-    void deleteBookByUserIdAndBookId(Long userId, Long bookId);
-
-    Optional<BookShelf> findByUserIdAndBookId(Long userId, Long bookId);
-
-    void deleteAllByUserId(Long userId);
+    Page<BookShelf> findSpecificStatusBookByUserId(ReadingStatus readingStatus, Pageable pageable,
+        Long userId);
 
     Optional<BookShelf> findByUserIdAndIsbnAndPublishAt(Long userId, String isbn,
         LocalDate publishAt);
 
     Optional<BookShelf> findByIdAndUserId(Long bookShelfId, Long userId);
+
+    void deleteBookShelfByIdAndUserId(Long bookShelfId, Long userId);
+
+    void deleteAllByUserId(Long userId);
+
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/bookshelf/repository/query/BookShelfQueryRepository.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookshelf/repository/query/BookShelfQueryRepository.java
@@ -20,4 +20,6 @@ public interface BookShelfQueryRepository {
 
     Optional<BookShelf> findByUserIdAndIsbnAndPublishAt(Long userId, String isbn,
         LocalDate publishAt);
+
+    Optional<BookShelf> findByIdAndUserId(Long bookShelfId, Long userId);
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/bookshelf/repository/query/BookShelfQueryRepository.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookshelf/repository/query/BookShelfQueryRepository.java
@@ -17,8 +17,9 @@ public interface BookShelfQueryRepository {
 
     Optional<BookShelf> findByIdAndUserId(Long bookShelfId, Long userId);
 
+    Optional<BookShelf> findWithReportByIdAndUserId(Long bookShelfId, Long userId);
+
     void deleteBookShelfByIdAndUserId(Long bookShelfId, Long userId);
 
     void deleteAllByUserId(Long userId);
-
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/bookshelf/repository/query/BookShelfQueryRepositoryImpl.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookshelf/repository/query/BookShelfQueryRepositoryImpl.java
@@ -1,7 +1,6 @@
 package toy.bookchat.bookchat.domain.bookshelf.repository.query;
 
 import static toy.bookchat.bookchat.domain.book.QBook.book;
-import static toy.bookchat.bookchat.domain.bookreport.QBookReport.bookReport;
 import static toy.bookchat.bookchat.domain.bookshelf.QBookShelf.bookShelf;
 import static toy.bookchat.bookchat.domain.common.RepositorySupport.extractOrderSpecifierFrom;
 
@@ -51,23 +50,13 @@ public class BookShelfQueryRepositoryImpl implements BookShelfQueryRepository {
     }
 
     @Override
-    public void deleteBookByUserIdAndBookId(Long userId, Long bookId) {
+    public void deleteBookShelfByIdAndUserId(Long bookShelfId, Long userId) {
         queryFactory.delete(bookShelf)
-            .where(bookShelf.user.id.eq(userId)
-                .and(bookShelf.book.id.eq(bookId)))
+            .where(bookShelf.id.eq(bookShelfId)
+                .and(bookShelf.user.id.eq(userId)))
             .execute();
     }
-
-    @Override
-    public Optional<BookShelf> findByUserIdAndBookId(Long userId, Long bookId) {
-        return Optional.ofNullable(queryFactory.select(bookShelf)
-            .from(bookShelf).join(bookShelf.book, book).fetchJoin()
-            .leftJoin(bookShelf.bookReport, bookReport).fetchJoin()
-            .where(bookShelf.user.id.eq(userId)
-                .and(bookShelf.book.id.eq(bookId)))
-            .fetchOne());
-    }
-
+    
     @Override
     public void deleteAllByUserId(Long userId) {
         queryFactory.delete(bookShelf)

--- a/src/main/java/toy/bookchat/bookchat/domain/bookshelf/repository/query/BookShelfQueryRepositoryImpl.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookshelf/repository/query/BookShelfQueryRepositoryImpl.java
@@ -84,4 +84,13 @@ public class BookShelfQueryRepositoryImpl implements BookShelfQueryRepository {
                 .and(bookShelf.book.publishAt.eq(publishAt)))
             .fetchOne());
     }
+
+    @Override
+    public Optional<BookShelf> findByIdAndUserId(Long bookShelfId, Long userId) {
+        return Optional.ofNullable(queryFactory.select(bookShelf)
+            .from(bookShelf)
+            .where(bookShelf.id.eq(bookShelfId)
+                .and(bookShelf.user.id.eq(userId)))
+            .fetchOne());
+    }
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/bookshelf/repository/query/BookShelfQueryRepositoryImpl.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookshelf/repository/query/BookShelfQueryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package toy.bookchat.bookchat.domain.bookshelf.repository.query;
 
 import static toy.bookchat.bookchat.domain.book.QBook.book;
+import static toy.bookchat.bookchat.domain.bookreport.QBookReport.bookReport;
 import static toy.bookchat.bookchat.domain.bookshelf.QBookShelf.bookShelf;
 import static toy.bookchat.bookchat.domain.common.RepositorySupport.extractOrderSpecifierFrom;
 
@@ -56,7 +57,7 @@ public class BookShelfQueryRepositoryImpl implements BookShelfQueryRepository {
                 .and(bookShelf.user.id.eq(userId)))
             .execute();
     }
-    
+
     @Override
     public void deleteAllByUserId(Long userId) {
         queryFactory.delete(bookShelf)
@@ -81,5 +82,16 @@ public class BookShelfQueryRepositoryImpl implements BookShelfQueryRepository {
             .where(bookShelf.id.eq(bookShelfId)
                 .and(bookShelf.user.id.eq(userId)))
             .fetchOne());
+    }
+
+    @Override
+    public Optional<BookShelf> findWithReportByIdAndUserId(Long bookShelfId, Long userId) {
+        return Optional.ofNullable(queryFactory.select(bookShelf)
+            .from(bookShelf)
+            .join(bookShelf.bookReport, bookReport).fetchJoin()
+            .where(bookShelf.id.eq(bookShelfId)
+                .and(bookShelf.user.id.eq(userId)))
+            .fetchOne());
+
     }
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/bookshelf/service/BookShelfService.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookshelf/service/BookShelfService.java
@@ -62,9 +62,8 @@ public class BookShelfService {
     }
 
     @Transactional(readOnly = true)
-    public SearchBookShelfByReadingStatus takeBooksOutOfBookShelf(ReadingStatus readingStatus,
+    public SearchBookShelfByReadingStatus takeBooksOutOfBookShelves(ReadingStatus readingStatus,
         Pageable pageable, Long userId) {
-
         Page<BookShelf> pagingBookShelves = bookShelfRepository.findSpecificStatusBookByUserId(
             readingStatus, pageable,
             userId);
@@ -83,18 +82,17 @@ public class BookShelfService {
     }
 
     @Transactional
-    public void reviseBookShelf(Long bookId, ReviseBookShelfRequest reviseBookShelfRequest,
+    public void reviseBookShelf(Long bookShelfId, ReviseBookShelfRequest reviseBookShelfRequest,
         Long userId) {
-        BookShelf bookShelf = bookShelfRepository.findByUserIdAndBookId(userId, bookId)
+        BookShelf bookShelf = bookShelfRepository.findByIdAndUserId(bookShelfId, userId)
             .orElseThrow(BookNotFoundException::new);
 
         reviseBookShelfRequest.applyChanges(bookShelf);
     }
 
     @Transactional
-    public void deleteBookOnBookShelf(Long bookId, Long userId) {
-        bookShelfRepository.deleteBookByUserIdAndBookId(userId,
-            bookId);
+    public void deleteBookShelf(Long bookShelfId, Long userId) {
+        bookShelfRepository.deleteBookShelfByIdAndUserId(bookShelfId, userId);
     }
 
     @Transactional

--- a/src/main/java/toy/bookchat/bookchat/domain/bookshelf/service/dto/response/BookShelfResponse.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookshelf/service/dto/response/BookShelfResponse.java
@@ -9,6 +9,7 @@ import toy.bookchat.bookchat.domain.bookshelf.Star;
 @Getter
 public class BookShelfResponse {
 
+    private Long bookShelfId;
     private Long bookId;
     private String title;
     private String isbn;
@@ -20,9 +21,10 @@ public class BookShelfResponse {
     private Integer pages;
 
     @Builder
-    private BookShelfResponse(Long bookId, String title, String isbn,
+    private BookShelfResponse(Long bookShelfId, Long bookId, String title, String isbn,
         String bookCoverImageUrl, LocalDate publishAt, List<String> authors, String publisher,
         Star star, Integer pages) {
+        this.bookShelfId = bookShelfId;
         this.bookId = bookId;
         this.title = title;
         this.isbn = isbn;

--- a/src/main/java/toy/bookchat/bookchat/domain/bookshelf/service/dto/response/BookShelfResponse.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookshelf/service/dto/response/BookShelfResponse.java
@@ -10,7 +10,6 @@ import toy.bookchat.bookchat.domain.bookshelf.Star;
 public class BookShelfResponse {
 
     private Long bookShelfId;
-    private Long bookId;
     private String title;
     private String isbn;
     private String bookCoverImageUrl;
@@ -21,11 +20,10 @@ public class BookShelfResponse {
     private Integer pages;
 
     @Builder
-    private BookShelfResponse(Long bookShelfId, Long bookId, String title, String isbn,
+    private BookShelfResponse(Long bookShelfId, String title, String isbn,
         String bookCoverImageUrl, LocalDate publishAt, List<String> authors, String publisher,
         Star star, Integer pages) {
         this.bookShelfId = bookShelfId;
-        this.bookId = bookId;
         this.title = title;
         this.isbn = isbn;
         this.bookCoverImageUrl = bookCoverImageUrl;

--- a/src/main/java/toy/bookchat/bookchat/domain/bookshelf/service/dto/response/ExistenceBookOnBookShelfResponse.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookshelf/service/dto/response/ExistenceBookOnBookShelfResponse.java
@@ -9,19 +9,17 @@ import toy.bookchat.bookchat.domain.bookshelf.ReadingStatus;
 public class ExistenceBookOnBookShelfResponse {
 
     private Long bookShelfId;
-    private Long bookId;
     private ReadingStatus readingStatus;
 
     @Builder
-    private ExistenceBookOnBookShelfResponse(Long bookShelfId, Long bookId,
+    private ExistenceBookOnBookShelfResponse(Long bookShelfId,
         ReadingStatus readingStatus) {
         this.bookShelfId = bookShelfId;
-        this.bookId = bookId;
         this.readingStatus = readingStatus;
     }
 
     public static ExistenceBookOnBookShelfResponse from(BookShelf bookShelf) {
-        return new ExistenceBookOnBookShelfResponse(bookShelf.getId(), bookShelf.getBookId(),
+        return new ExistenceBookOnBookShelfResponse(bookShelf.getId(),
             bookShelf.getReadingStatus());
     }
 }

--- a/src/main/java/toy/bookchat/bookchat/domain/bookshelf/service/dto/response/SearchBookShelfByReadingStatus.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookshelf/service/dto/response/SearchBookShelfByReadingStatus.java
@@ -24,7 +24,6 @@ public class SearchBookShelfByReadingStatus {
         for (BookShelf bookShelf : bookShelves) {
             BookShelfResponse bookShelfResponse = BookShelfResponse.builder()
                 .bookShelfId(bookShelf.getId())
-                .bookId(bookShelf.getBookId())
                 .title(bookShelf.getBookTitle())
                 .isbn(bookShelf.getIsbn())
                 .authors(bookShelf.getBookAuthors())

--- a/src/main/java/toy/bookchat/bookchat/domain/bookshelf/service/dto/response/SearchBookShelfByReadingStatus.java
+++ b/src/main/java/toy/bookchat/bookchat/domain/bookshelf/service/dto/response/SearchBookShelfByReadingStatus.java
@@ -23,6 +23,7 @@ public class SearchBookShelfByReadingStatus {
 
         for (BookShelf bookShelf : bookShelves) {
             BookShelfResponse bookShelfResponse = BookShelfResponse.builder()
+                .bookShelfId(bookShelf.getId())
                 .bookId(bookShelf.getBookId())
                 .title(bookShelf.getBookTitle())
                 .isbn(bookShelf.getIsbn())

--- a/src/main/java/toy/bookchat/bookchat/localtest/rest/agony/AgonyAPI.http
+++ b/src/main/java/toy/bookchat/bookchat/localtest/rest/agony/AgonyAPI.http
@@ -1,26 +1,26 @@
 ### 고민 폴더 생성
-POST localhost:8080/v1/api/bookshelf/books/{{bookId}}/agonies
+POST localhost:8080/v1/api/bookshelves/{{bookShelfId}}/agonies
 Authorization: {{jwt_token}}
 Content-Type: application/json
 
 {
-  "title": "고민1",
+  "title": "고민5",
   "hexColorCode": "파랑"
 }
 
 ### 고민 폴더 조회
-GET localhost:8080/v1/api/agonies?postCursorId=0&size=3&sort=id,DESC
+GET localhost:8080/v1/api/bookshelves/{{bookShelfId}}/agonies?postCursorId=0&size=3&sort=id,ASC
 Authorization: {{jwt_token}}
 
 > {%
-client.test("Request executed successfully", function() {
-client.assert(response.status === 200, "Response status is not 200");
-});
-client.global.set("agonyId", response.body.agonyResponseList[0].agonyId);
+  client.test("Request executed successfully", function () {
+    client.assert(response.status === 200, "Response status is not 200");
+  });
+  client.global.set("agonyId", response.body.agonyResponseList[0].agonyId);
 %}
 
 ### 고민 폴더 수정
-PUT localhost:8080/v1/api/agonies/{{agonyId}}
+PUT localhost:8080/v1/api/bookshelves/{{bookShelfId}}/agonies/{{agonyId}}
 Authorization: {{jwt_token}}
 Content-Type: application/json
 
@@ -30,5 +30,5 @@ Content-Type: application/json
 }
 
 ### 고민 폴더 삭제
-DELETE localhost:8080/v1/api/agonies/{{agonyId}}
+DELETE localhost:8080/v1/api/bookshelves/{{bookShelfId}}/agonies/{{agonyId}}
 Authorization: {{jwt_token}}

--- a/src/main/java/toy/bookchat/bookchat/localtest/rest/agonyrecord/AgonyRecordAPI.http
+++ b/src/main/java/toy/bookchat/bookchat/localtest/rest/agonyrecord/AgonyRecordAPI.http
@@ -1,5 +1,5 @@
 ### 고민기록 생성
-POST localhost:8080/v1/api/agonies/{{agonyId}}/records
+POST localhost:8080/v1/api/bookshelves/{{bookShelfId}}/agonies/{{agonyId}}/records
 Authorization: {{jwt_token}}
 Content-Type: application/json
 
@@ -9,18 +9,19 @@ Content-Type: application/json
 }
 
 ### 고민기록 조회
-GET localhost:8080/v1/api/agonies/{{agonyId}}/records?page=0&size=3&sort=id,ASC
+GET localhost:8080/v1/api/bookshelves/{{bookShelfId}}/agonies/{{agonyId}}/records?page=0&size=3&
+    sort=id,ASC
 Authorization: {{jwt_token}}
 
 > {%
-client.test("Request executed successfully", function() {
-client.assert(response.status === 200, "Response status is not 200");
-});
-client.global.set("recordId", response.body.agonyRecordResponseList[0].agonyRecordId);
+  client.test("Request executed successfully", function () {
+    client.assert(response.status === 200, "Response status is not 200");
+  });
+  client.global.set("recordId", response.body.agonyRecordResponseList[0].agonyRecordId);
 %}
 
 ### 고민기록 수정
-PUT localhost:8080/v1/api/agonies/{{agonyId}}/records/{{recordId}}
+PUT localhost:8080/v1/api/bookshelves/{{bookShelfId}}/agonies/{{agonyId}}/records/{{recordId}}
 Authorization: {{jwt_token}}
 Content-Type: application/json
 
@@ -30,5 +31,5 @@ Content-Type: application/json
 }
 
 ### 고민기록 삭제
-DELETE localhost:8080/v1/api/agonies/{{agonyId}}/records/{{recordId}}
+DELETE localhost:8080/v1/api/bookshelves/{{bookShelfId}}/agonies/{{agonyId}}/records/{{recordId}}
 Authorization: {{jwt_token}}

--- a/src/main/java/toy/bookchat/bookchat/localtest/rest/bookreport/BookReportAPI.http
+++ b/src/main/java/toy/bookchat/bookchat/localtest/rest/bookreport/BookReportAPI.http
@@ -1,5 +1,5 @@
 ### 독후감 작성
-POST localhost:8080/v1/api/books/{{bookId}}/report
+POST localhost:8080/v1/api/bookshelves/{{bookShelfId}}/report
 Authorization: {{jwt_token}}
 Content-Type: application/json
 
@@ -9,15 +9,15 @@ Content-Type: application/json
 }
 
 ### 독후감 조회
-GET localhost:8080/v1/api/books/{{bookId}}/report
+GET localhost:8080/v1/api/bookshelves/{{bookShelfId}}/report
 Authorization: {{jwt_token}}
 
 ### 독후감 삭제
-DELETE localhost:8080/v1/api/books/{{bookId}}/report
+DELETE localhost:8080/v1/api/bookshelves/{{bookShelfId}}/report
 Authorization: {{jwt_token}}
 
 ### 독후감 수정
-PUT localhost:8080/v1/api/books/{{bookId}}/report
+PUT localhost:8080/v1/api/bookshelves/{{bookShelfId}}/report
 Authorization: {{jwt_token}}
 Content-Type: application/json
 

--- a/src/main/java/toy/bookchat/bookchat/localtest/rest/bookshelf/BookShelfAPI.http
+++ b/src/main/java/toy/bookchat/bookchat/localtest/rest/bookshelf/BookShelfAPI.http
@@ -1,13 +1,15 @@
 ### 서재에 책 등록
-POST localhost:8080/v1/api/bookshelf/books
+POST localhost:8080/v1/api/bookshelves
 Authorization: {{jwt_token}}
 Content-Type: application/json
 
 {
   "bookRequest": {
-    "isbn": "1162240032 9791162240038",
-    "title": "Effective C#(이펙티브)",
-    "authors": ["빌 와그너"],
+    "isbn": "1162240033 9791162240038",
+    "title": "Effective C#(이펙티브2)",
+    "authors": [
+      "빌 와그너"
+    ],
     "publisher": "한빛미디어",
     "bookCoverImageUrl": "https://search1.kakaocdn.net/thumb/R120x174.q85/?fname=http%3A%2F%2Ft1.daumcdn.net%2Flbook%2Fimage%2F1611826%3Ftimestamp%3D20221107221559",
     "publishAt": "2017-11-06"
@@ -17,24 +19,24 @@ Content-Type: application/json
 }
 
 ### 서재에서 책 조회
-GET localhost:8080/v1/api/bookshelf/books?readingStatus=READING&size=1&page=0&sort=id,ASC
+GET localhost:8080/v1/api/bookshelves?readingStatus=READING&size=1&page=0&sort=id,ASC
 Authorization: {{jwt_token}}
 
 > {%
-client.test("Request executed successfully", function() {
-client.assert(response.status === 200, "Response status is not 200");
-});
-client.global.set("bookId", response.body.contents[0].bookId);
-client.global.set("isbn", response.body.contents[0].isbn);
-client.global.set("publishAt", response.body.contents[0].publishAt);
+  client.test("Request executed successfully", function () {
+    client.assert(response.status === 200, "Response status is not 200");
+  });
+  client.global.set("bookShelfId", response.body.contents[0].bookShelfId);
+  client.global.set("isbn", response.body.contents[0].isbn);
+  client.global.set("publishAt", response.body.contents[0].publishAt);
 %}
 
 ### 서재에서 책 삭제
-DELETE localhost:8080/v1/api/bookshelf/books/{{bookId}}
+DELETE localhost:8080/v1/api/bookshelves{{bookShelfId}}
 Authorization: {{jwt_token}}
 
 ### 서재 페이지|별점|독서상태변경
-PUT localhost:8080/v1/api/bookshelf/books/{{bookId}}/pages
+PUT localhost:8080/v1/api/bookshelves/{{bookShelfId}}
 Authorization: {{jwt_token}}
 Content-Type: application/json
 
@@ -45,5 +47,5 @@ Content-Type: application/json
 }
 
 ### 서재에 등록된 책이면 조회
-GET localhost:8080/v1/api/bookshelf/books/existence?isbn={{isbn}}&publishAt={{publishAt}}
+GET localhost:8080/v1/api/bookshelves/book?isbn={{isbn}}&publishAt={{publishAt}}
 Authorization: {{jwt_token}}

--- a/src/test/java/toy/bookchat/bookchat/domain/agony/api/AgonyControllerTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/agony/api/AgonyControllerTest.java
@@ -107,7 +107,7 @@ class AgonyControllerTest extends ControllerTestExtension {
         SliceOfAgoniesResponse pageOfAgoniesResponse = new SliceOfAgoniesResponse(slice);
         when(agonyService.searchSliceOfAgonies(any(), any(), any())).thenReturn(
             pageOfAgoniesResponse);
-        mockMvc.perform(get("/v1/api/agonies")
+        mockMvc.perform(get("/v1/api/bookshelf/books/{bookId}/agonies")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .queryParam("size", "2")
@@ -118,6 +118,9 @@ class AgonyControllerTest extends ControllerTestExtension {
             .andDo(document("get-agonies",
                 requestHeaders(
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
+                ),
+                pathParameters(
+                    parameterWithName("bookId")
                 ),
                 requestParameters(
                     parameterWithName("size").description("page 당 size"),

--- a/src/test/java/toy/bookchat/bookchat/domain/agony/api/AgonyControllerTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/agony/api/AgonyControllerTest.java
@@ -77,7 +77,7 @@ class AgonyControllerTest extends ControllerTestExtension {
     void 고민_생성_성공() throws Exception {
         CreateBookAgonyRequest createBookAgonyRequest = new CreateBookAgonyRequest("title",
             "#062498");
-        mockMvc.perform(post("/v1/api/bookshelf/books/{bookId}/agonies", 1)
+        mockMvc.perform(post("/v1/api/bookshelf/{bookShelfId}/agonies", 1)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .contentType(APPLICATION_JSON)
@@ -88,14 +88,14 @@ class AgonyControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
-                    parameterWithName("bookId").description("Book Id")
+                    parameterWithName("bookShelfId").description("BookShelf Id")
                 ),
                 requestFields(
                     fieldWithPath("title").type(STRING).description("고민 제목"),
                     fieldWithPath("hexColorCode").type(STRING).description("고민 폴더 색상")
                 )));
 
-        verify(agonyService).storeBookAgony(any(), any(), any());
+        verify(agonyService).storeBookShelfAgony(any(), any(), any());
     }
 
     @Test

--- a/src/test/java/toy/bookchat/bookchat/domain/agony/api/AgonyControllerTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/agony/api/AgonyControllerTest.java
@@ -77,7 +77,7 @@ class AgonyControllerTest extends ControllerTestExtension {
     void 고민_생성_성공() throws Exception {
         CreateBookAgonyRequest createBookAgonyRequest = new CreateBookAgonyRequest("title",
             "#062498");
-        mockMvc.perform(post("/v1/api/bookshelf/{bookShelfId}/agonies", 1)
+        mockMvc.perform(post("/v1/api/bookshelves/{bookShelfId}/agonies", 1)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .contentType(APPLICATION_JSON)
@@ -106,7 +106,7 @@ class AgonyControllerTest extends ControllerTestExtension {
         SliceOfAgoniesResponse pageOfAgoniesResponse = new SliceOfAgoniesResponse(slice);
         when(agonyService.searchSliceOfAgonies(any(), any(), any(), any())).thenReturn(
             pageOfAgoniesResponse);
-        mockMvc.perform(get("/v1/api/bookshelf/{bookShelfId}/agonies", 1)
+        mockMvc.perform(get("/v1/api/bookshelves/{bookShelfId}/agonies", 1)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .queryParam("size", "2")
@@ -138,7 +138,7 @@ class AgonyControllerTest extends ControllerTestExtension {
 
     @Test
     void 고민_폴더_삭제_성공() throws Exception {
-        mockMvc.perform(delete("/v1/api/bookshelf/{bookShelfId}/agonies/{agoniesIds}", 1, "1,2,3")
+        mockMvc.perform(delete("/v1/api/bookshelves/{bookShelfId}/agonies/{agoniesIds}", 1, "1,2,3")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal())))
             .andExpect(status().isOk())
@@ -161,7 +161,7 @@ class AgonyControllerTest extends ControllerTestExtension {
             .hexColorCode("보라색")
             .build();
 
-        mockMvc.perform(put("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}", 1L, 1L)
+        mockMvc.perform(put("/v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}", 1L, 1L)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .contentType(APPLICATION_JSON)

--- a/src/test/java/toy/bookchat/bookchat/domain/agony/api/AgonyControllerTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/agony/api/AgonyControllerTest.java
@@ -100,14 +100,13 @@ class AgonyControllerTest extends ControllerTestExtension {
 
     @Test
     void 고민_조회_성공() throws Exception {
-
         List<Agony> agonies = getAgonies();
         PageRequest pageRequest = PageRequest.of(0, 2, Sort.by("id").descending());
         Slice<Agony> slice = new SliceImpl<>(agonies, pageRequest, true);
         SliceOfAgoniesResponse pageOfAgoniesResponse = new SliceOfAgoniesResponse(slice);
-        when(agonyService.searchSliceOfAgonies(any(), any(), any())).thenReturn(
+        when(agonyService.searchSliceOfAgonies(any(), any(), any(), any())).thenReturn(
             pageOfAgoniesResponse);
-        mockMvc.perform(get("/v1/api/bookshelf/books/{bookId}/agonies")
+        mockMvc.perform(get("/v1/api/bookshelf/{bookShelfId}/agonies", 1)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .queryParam("size", "2")
@@ -120,7 +119,7 @@ class AgonyControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
-                    parameterWithName("bookId")
+                    parameterWithName("bookShelfId").description("BookShelf Id")
                 ),
                 requestParameters(
                     parameterWithName("size").description("page 당 size"),
@@ -139,7 +138,7 @@ class AgonyControllerTest extends ControllerTestExtension {
 
     @Test
     void 고민_폴더_삭제_성공() throws Exception {
-        mockMvc.perform(delete("/v1/api/agonies/{agoniesIds}", "1,2,3")
+        mockMvc.perform(delete("/v1/api/bookshelf/{bookShelfId}/agonies/{agoniesIds}", 1, "1,2,3")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal())))
             .andExpect(status().isOk())
@@ -148,10 +147,11 @@ class AgonyControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
+                    parameterWithName("bookShelfId").description("BookShelf Id"),
                     parameterWithName("agoniesIds").description("삭제할 고민폴더 ID")
                 )));
 
-        verify(agonyService).deleteAgony(any(), any());
+        verify(agonyService).deleteAgony(any(), any(), any());
     }
 
     @Test
@@ -161,7 +161,7 @@ class AgonyControllerTest extends ControllerTestExtension {
             .hexColorCode("보라색")
             .build();
 
-        mockMvc.perform(put("/v1/api/agonies/{agonyId}", 1L)
+        mockMvc.perform(put("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}", 1L, 1L)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .contentType(APPLICATION_JSON)
@@ -172,6 +172,7 @@ class AgonyControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
+                    parameterWithName("bookShelfId").description("BookShelf Id"),
                     parameterWithName("agonyId").description("Agony Id")
                 ),
                 requestFields(
@@ -179,6 +180,6 @@ class AgonyControllerTest extends ControllerTestExtension {
                     fieldWithPath("hexColorCode").type(STRING).description("고민 폴더 색")
                 )));
 
-        verify(agonyService).reviseAgony(any(), any(), any());
+        verify(agonyService).reviseAgony(any(), any(), any(), any());
     }
 }

--- a/src/test/java/toy/bookchat/bookchat/domain/agony/repository/AgonyRepositoryTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/agony/repository/AgonyRepositoryTest.java
@@ -58,7 +58,6 @@ class AgonyRepositoryTest {
             .title("title")
             .hexColorCode("blue")
             .bookShelf(bookShelf)
-            .user(bookShelf.getUser())
             .build();
     }
 
@@ -96,7 +95,8 @@ class AgonyRepositoryTest {
         Agony agony = getAgony(bookShelf);
         agonyRepository.save(agony);
 
-        Agony findAgony = agonyRepository.findUserBookShelfAgony(user.getId(), agony.getId()).get();
+        Agony findAgony = agonyRepository.findUserBookShelfAgony(bookShelf.getId(), agony.getId(),
+            user.getId()).get();
 
         assertThat(findAgony).isEqualTo(agony);
     }
@@ -120,7 +120,8 @@ class AgonyRepositoryTest {
         agonyRepository.saveAll(agonyList);
 
         PageRequest pageRequest = PageRequest.of(0, 2, Sort.by("id").descending());
-        Slice<Agony> pageOfAgonies = agonyRepository.findUserBookShelfSliceOfAgonies(user.getId(),
+        Slice<Agony> pageOfAgonies = agonyRepository.findUserBookShelfSliceOfAgonies(
+            bookShelf.getId(), user.getId(),
             pageRequest, Optional.empty());
 
         List<Agony> content = pageOfAgonies.getContent();
@@ -147,7 +148,8 @@ class AgonyRepositoryTest {
         agonyRepository.save(agony3);
 
         PageRequest pageRequest = PageRequest.of(0, 2, Sort.by("id").descending());
-        Slice<Agony> pageOfAgonies = agonyRepository.findUserBookShelfSliceOfAgonies(user.getId(),
+        Slice<Agony> pageOfAgonies = agonyRepository.findUserBookShelfSliceOfAgonies(
+            bookShelf.getId(), user.getId(),
             pageRequest, Optional.of(agony3.getId()));
 
         List<Agony> content = pageOfAgonies.getContent();
@@ -173,7 +175,8 @@ class AgonyRepositoryTest {
         agonyRepository.saveAllAndFlush(agonyList);
 
         PageRequest pageRequest = PageRequest.of(0, 2, Sort.by("id").ascending());
-        Slice<Agony> pageOfAgonies = agonyRepository.findUserBookShelfSliceOfAgonies(user.getId(),
+        Slice<Agony> pageOfAgonies = agonyRepository.findUserBookShelfSliceOfAgonies(
+            bookShelf.getId(), user.getId(),
             pageRequest, Optional.of(agony1.getId()));
 
         List<Agony> content = pageOfAgonies.getContent();
@@ -200,7 +203,8 @@ class AgonyRepositoryTest {
 
         PageRequest pageRequest = PageRequest.of(0, 2, Sort.by("title").ascending());
         assertThatThrownBy(() -> {
-            agonyRepository.findUserBookShelfSliceOfAgonies(user.getId(), pageRequest,
+            agonyRepository.findUserBookShelfSliceOfAgonies(bookShelf.getId(), user.getId(),
+                pageRequest,
                 Optional.of(agony1.getId()));
         }).isInstanceOf(NotSupportedPagingConditionException.class);
     }
@@ -224,7 +228,7 @@ class AgonyRepositoryTest {
         agonyRepository.saveAll(agonyList);
 
         List<Long> agoniesIds = List.of(agony1.getId(), agony2.getId(), agony3.getId());
-        agonyRepository.deleteByAgoniesIds(user.getId(), agoniesIds);
+        agonyRepository.deleteByAgoniesIds(bookShelf.getId(), user.getId(), agoniesIds);
 
         List<Agony> result = agonyRepository.findAll();
         assertThat(result).isEmpty();

--- a/src/test/java/toy/bookchat/bookchat/domain/agony/service/AgonyServiceTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/agony/service/AgonyServiceTest.java
@@ -55,10 +55,10 @@ class AgonyServiceTest {
         BookShelf bookShelf = mock(BookShelf.class);
         CreateBookAgonyRequest createBookAgonyRequest = mock(CreateBookAgonyRequest.class);
 
-        when(bookShelfRepository.findByUserIdAndBookId(any(), any())).thenReturn(
+        when(bookShelfRepository.findByIdAndUserId(any(), any())).thenReturn(
             Optional.of(bookShelf));
 
-        agonyService.storeBookAgony(createBookAgonyRequest, 1L, 1L);
+        agonyService.storeBookShelfAgony(createBookAgonyRequest, 1L, 1L);
 
         verify(agonyRepository).save(any());
     }
@@ -68,7 +68,7 @@ class AgonyServiceTest {
         CreateBookAgonyRequest createBookAgonyRequest = mock(CreateBookAgonyRequest.class);
 
         assertThatThrownBy(() -> {
-            agonyService.storeBookAgony(createBookAgonyRequest, 1L, 1L);
+            agonyService.storeBookShelfAgony(createBookAgonyRequest, 1L, 1L);
         }).isInstanceOf(BookNotFoundException.class);
     }
 

--- a/src/test/java/toy/bookchat/bookchat/domain/agony/service/AgonyServiceTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/agony/service/AgonyServiceTest.java
@@ -81,9 +81,9 @@ class AgonyServiceTest {
 
         List<Agony> contents = List.of(agony1, agony2);
         Slice<Agony> page = new SliceImpl<>(contents, pageRequest, true);
-        when(agonyRepository.findUserBookShelfSliceOfAgonies(1L, pageRequest,
+        when(agonyRepository.findUserBookShelfSliceOfAgonies(1L, 1L, pageRequest,
             Optional.of(1L))).thenReturn(page);
-        SliceOfAgoniesResponse pageOfAgoniesResponse = agonyService.searchSliceOfAgonies(1L,
+        SliceOfAgoniesResponse pageOfAgoniesResponse = agonyService.searchSliceOfAgonies(1L, 1L,
             pageRequest, Optional.of(1L));
 
         String title = pageOfAgoniesResponse.getAgonyResponseList().get(0).getTitle();
@@ -92,10 +92,10 @@ class AgonyServiceTest {
 
     @Test
     void 고민폴더_삭제_성공() throws Exception {
-        agonyService.deleteAgony(List.of(1L, 2L, 3L), 1L);
+        agonyService.deleteAgony(1L, List.of(1L, 2L, 3L), 1L);
 
-        verify(agonyRecordRepository).deleteByAgoniesIds(any(), any());
-        verify(agonyRepository).deleteByAgoniesIds(any(), any());
+        verify(agonyRecordRepository).deleteByAgoniesIds(any(), any(), any());
+        verify(agonyRepository).deleteByAgoniesIds(any(), any(), any());
     }
 
     @Test
@@ -106,10 +106,10 @@ class AgonyServiceTest {
             .title("폴더 이름 바꾸기")
             .hexColorCode("보라색")
             .build();
-        when(agonyRepository.findUserBookShelfAgony(any(), any())).thenReturn(
+        when(agonyRepository.findUserBookShelfAgony(any(), any(), any())).thenReturn(
             Optional.of(agony));
 
-        agonyService.reviseAgony(1L, 1L, reviseAgonyRequest);
+        agonyService.reviseAgony(1L, 1L, 1L, reviseAgonyRequest);
 
         String result = agony.getHexColorCode();
         assertThat(result).isEqualTo("보라색");

--- a/src/test/java/toy/bookchat/bookchat/domain/agonyrecord/api/AgonyRecordControllerTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/agonyrecord/api/AgonyRecordControllerTest.java
@@ -58,7 +58,7 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
         CreateAgonyRecordRequest createAgonyRecordRequest = new CreateAgonyRecordRequest(
             "title", "blabla");
 
-        mockMvc.perform(post("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records", 1, 1)
+        mockMvc.perform(post("/v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}/records", 1, 1)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .contentType(APPLICATION_JSON)
@@ -104,7 +104,7 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
         when(agonyRecordService.searchPageOfAgonyRecords(any(), any(), any(), any(),
             any())).thenReturn(
             pageOfAgonyRecordsResponse);
-        mockMvc.perform(get("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records", 1, 1)
+        mockMvc.perform(get("/v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}/records", 1, 1)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .queryParam("postCursorId", "1")
@@ -140,7 +140,7 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
     @Test
     void 고민기록_삭제_성공() throws Exception {
         mockMvc.perform(
-                delete("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records/{recordId}", 1L, 1L,
+                delete("/v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}/records/{recordId}", 1L, 1L,
                     1L)
                     .header(AUTHORIZATION, JWT_TOKEN)
                     .with(user(getUserPrincipal())))
@@ -166,7 +166,8 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
             .build();
 
         mockMvc.perform(
-                put("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records/{recordId}", 1L, 1L, 1L)
+                put("/v1/api/bookshelves/{bookShelfId}/agonies/{agonyId}/records/{recordId}", 1L, 1L,
+                    1L)
                     .header(AUTHORIZATION, JWT_TOKEN)
                     .with(user(getUserPrincipal()))
                     .contentType(APPLICATION_JSON)

--- a/src/test/java/toy/bookchat/bookchat/domain/agonyrecord/api/AgonyRecordControllerTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/agonyrecord/api/AgonyRecordControllerTest.java
@@ -58,7 +58,7 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
         CreateAgonyRecordRequest createAgonyRecordRequest = new CreateAgonyRecordRequest(
             "title", "blabla");
 
-        mockMvc.perform(post("/v1/api/agonies/{agonyId}/records", 1)
+        mockMvc.perform(post("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records", 1, 1)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .contentType(APPLICATION_JSON)
@@ -69,6 +69,7 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
+                    parameterWithName("bookShelfId").description("BookShelf Id"),
                     parameterWithName("agonyId").description("Agony Id")
                 ),
                 requestFields(
@@ -76,7 +77,7 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
                     fieldWithPath("content").optional().description("고민기록의 내용")
                 )));
 
-        verify(agonyRecordService).storeAgonyRecord(any(), any(), any());
+        verify(agonyRecordService).storeAgonyRecord(any(), any(), any(), any());
     }
 
     @Test
@@ -100,10 +101,10 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
         SliceOfAgonyRecordsResponse pageOfAgonyRecordsResponse = new SliceOfAgonyRecordsResponse(
             slice);
 
-        when(agonyRecordService.searchPageOfAgonyRecords(any(), any(), any(),
+        when(agonyRecordService.searchPageOfAgonyRecords(any(), any(), any(), any(),
             any())).thenReturn(
             pageOfAgonyRecordsResponse);
-        mockMvc.perform(get("/v1/api/agonies/{agonyId}/records", 1, 1)
+        mockMvc.perform(get("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records", 1, 1)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .queryParam("postCursorId", "1")
@@ -115,6 +116,7 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
+                    parameterWithName("bookShelfId").description("BookShelf Id"),
                     parameterWithName("agonyId").description("Agony Id")
                 ),
                 requestParameters(
@@ -138,7 +140,8 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
     @Test
     void 고민기록_삭제_성공() throws Exception {
         mockMvc.perform(
-                delete("/v1/api/agonies/{agonyId}/records/{recordId}", 1L, 1L)
+                delete("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records/{recordId}", 1L, 1L,
+                    1L)
                     .header(AUTHORIZATION, JWT_TOKEN)
                     .with(user(getUserPrincipal())))
             .andExpect(status().isOk())
@@ -147,11 +150,12 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
+                    parameterWithName("bookShelfId").description("BookShelf Id"),
                     parameterWithName("agonyId").description("Agony Id"),
                     parameterWithName("recordId").description("Record Id")
                 )));
 
-        verify(agonyRecordService).deleteAgonyRecord(any(), any(), any());
+        verify(agonyRecordService).deleteAgonyRecord(any(), any(), any(), any());
     }
 
     @Test
@@ -162,7 +166,7 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
             .build();
 
         mockMvc.perform(
-                put("/v1/api/agonies/{agonyId}/records/{recordId}", 1L, 1L)
+                put("/v1/api/bookshelf/{bookShelfId}/agonies/{agonyId}/records/{recordId}", 1L, 1L, 1L)
                     .header(AUTHORIZATION, JWT_TOKEN)
                     .with(user(getUserPrincipal()))
                     .contentType(APPLICATION_JSON)
@@ -173,6 +177,7 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
+                    parameterWithName("bookShelfId").description("BookShelf Id"),
                     parameterWithName("agonyId").description("Agony Id"),
                     parameterWithName("recordId").description("Record Id")
                 ),
@@ -181,6 +186,6 @@ class AgonyRecordControllerTest extends ControllerTestExtension {
                     fieldWithPath("recordContent").type(STRING).description("고민 기록 내용")
                 )));
 
-        verify(agonyRecordService).reviseAgonyRecord(any(), any(), any(), any());
+        verify(agonyRecordService).reviseAgonyRecord(any(), any(), any(), any(), any());
     }
 }

--- a/src/test/java/toy/bookchat/bookchat/domain/agonyrecord/repository/AgonyRecordRepositoryTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/agonyrecord/repository/AgonyRecordRepositoryTest.java
@@ -67,7 +67,6 @@ class AgonyRecordRepositoryTest {
             .title("title")
             .hexColorCode("blue")
             .bookShelf(bookShelf)
-            .user(bookShelf.getUser())
             .build();
     }
 
@@ -118,7 +117,9 @@ class AgonyRecordRepositoryTest {
         agonyRecordRepository.save(agonyRecord);
 
         Pageable pageable = PageRequest.of(0, 1, Sort.by("id").descending());
-        List<AgonyRecord> content = agonyRecordRepository.findSliceOfUserAgonyRecords(agony.getId(),
+        List<AgonyRecord> content = agonyRecordRepository.findSliceOfUserAgonyRecords(
+            bookShelf.getId(),
+            agony.getId(),
             user.getId(), pageable, Optional.empty()).getContent();
         assertThat(content).containsExactly(agonyRecord);
     }
@@ -145,7 +146,9 @@ class AgonyRecordRepositoryTest {
         agonyRecordRepository.save(agonyRecord3);
 
         Pageable pageable = PageRequest.of(0, 1, Sort.by("id").descending());
-        List<AgonyRecord> content = agonyRecordRepository.findSliceOfUserAgonyRecords(agony.getId(),
+        List<AgonyRecord> content = agonyRecordRepository.findSliceOfUserAgonyRecords(
+                bookShelf.getId(),
+                agony.getId(),
                 user.getId(), pageable, Optional.of(agonyRecord3.getId()))
             .getContent();
         assertThat(content).containsExactly(agonyRecord2);
@@ -173,7 +176,9 @@ class AgonyRecordRepositoryTest {
         agonyRecordRepository.save(agonyRecord3);
 
         Pageable pageable = PageRequest.of(0, 2, Sort.by("id").ascending());
-        List<AgonyRecord> content = agonyRecordRepository.findSliceOfUserAgonyRecords(agony.getId(),
+        List<AgonyRecord> content = agonyRecordRepository.findSliceOfUserAgonyRecords(
+                bookShelf.getId(),
+                agony.getId(),
                 user.getId(), pageable, Optional.of(agonyRecord1.getId()))
             .getContent();
         assertThat(content).containsExactly(agonyRecord2, agonyRecord3);
@@ -202,7 +207,8 @@ class AgonyRecordRepositoryTest {
 
         Pageable pageable = PageRequest.of(0, 2, Sort.by("title").ascending());
         assertThatThrownBy(() -> {
-            agonyRecordRepository.findSliceOfUserAgonyRecords(agony.getId(), user.getId(), pageable,
+            agonyRecordRepository.findSliceOfUserAgonyRecords(bookShelf.getId(), agony.getId(),
+                user.getId(), pageable,
                 Optional.of(agonyRecord1.getId()));
         }).isInstanceOf(NotSupportedPagingConditionException.class);
     }
@@ -224,8 +230,8 @@ class AgonyRecordRepositoryTest {
         AgonyRecord agonyRecord = getAgonyRecord(agony);
         agonyRecordRepository.save(agonyRecord);
 
-        agonyRecordRepository.deleteAgony(user.getId(), agony.getId(),
-            agonyRecord.getId());
+        agonyRecordRepository.deleteAgonyRecord(bookShelf.getId(), agony.getId(),
+            agonyRecord.getId(), user.getId());
 
         List<AgonyRecord> all = agonyRecordRepository.findAll();
         assertThat(all).isEmpty();
@@ -248,8 +254,8 @@ class AgonyRecordRepositoryTest {
         AgonyRecord agonyRecord = getAgonyRecord(agony);
         agonyRecordRepository.save(agonyRecord);
 
-        agonyRecordRepository.reviseAgonyRecord(user.getId(), agony.getId(),
-            agonyRecord.getId(), "수정 제목", "수정 내용");
+        agonyRecordRepository.reviseAgonyRecord(bookShelf.getId(), agony.getId(),
+            agonyRecord.getId(), user.getId(), "수정 제목", "수정 내용");
 
         em.flush();
         em.clear();
@@ -277,7 +283,8 @@ class AgonyRecordRepositoryTest {
         List<AgonyRecord> agonyRecords = List.of(agonyRecord1, agonyRecord2, agonyRecord3);
         agonyRecordRepository.saveAll(agonyRecords);
 
-        agonyRecordRepository.deleteByAgoniesIds(user.getId(), List.of(agony.getId()));
+        agonyRecordRepository.deleteByAgoniesIds(bookShelf.getId(), user.getId(),
+            List.of(agony.getId()));
 
         List<AgonyRecord> result = agonyRecordRepository.findAll();
         assertThat(result).isEmpty();

--- a/src/test/java/toy/bookchat/bookchat/domain/agonyrecord/service/AgonyRecordServiceTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/agonyrecord/service/AgonyRecordServiceTest.java
@@ -45,10 +45,10 @@ class AgonyRecordServiceTest {
             CreateAgonyRecordRequest.class);
         Agony agony = mock(Agony.class);
 
-        when(agonyRepository.findUserBookShelfAgony(any(), any())).thenReturn(
+        when(agonyRepository.findUserBookShelfAgony(any(), any(), any())).thenReturn(
             Optional.of(agony));
 
-        agonyRecordService.storeAgonyRecord(createAgonyRecordRequest, 1L, 1L);
+        agonyRecordService.storeAgonyRecord(1L, createAgonyRecordRequest, 1L, 1L);
 
         verify(agonyRecordRepository).save(any());
     }
@@ -59,7 +59,7 @@ class AgonyRecordServiceTest {
             CreateAgonyRecordRequest.class);
 
         assertThatThrownBy(() -> {
-            agonyRecordService.storeAgonyRecord(createAgonyRecordRequest, 1L, 1L);
+            agonyRecordService.storeAgonyRecord(1L, createAgonyRecordRequest, 1L, 1L);
         }).isInstanceOf(AgonyNotFoundException.class);
     }
 
@@ -83,11 +83,11 @@ class AgonyRecordServiceTest {
 
         Pageable pageable = PageRequest.of(0, 2, Sort.by("id").descending());
         Page<AgonyRecord> page = new PageImpl<>(list, pageable, list.size());
-        when(agonyRecordRepository.findSliceOfUserAgonyRecords(any(), any(),
+        when(agonyRecordRepository.findSliceOfUserAgonyRecords(any(), any(), any(),
             any(), any())).thenReturn(
             page);
         SliceOfAgonyRecordsResponse pageOfAgonyRecordsResponse = agonyRecordService.searchPageOfAgonyRecords(
-            1L, 1L, pageable, Optional.empty());
+            1L, 1L, 1L, pageable, Optional.empty());
 
         int result = pageOfAgonyRecordsResponse.getAgonyRecordResponseList().size();
         assertThat(result).isEqualTo(2);
@@ -95,9 +95,9 @@ class AgonyRecordServiceTest {
 
     @Test
     void 본인이_생성한_고민_기록_삭제_성공() throws Exception {
-        agonyRecordService.deleteAgonyRecord(1L, 1L, 1L);
+        agonyRecordService.deleteAgonyRecord(1L, 1L, 1L, 1L);
 
-        verify(agonyRecordRepository).deleteAgony(any(), any(), any());
+        verify(agonyRecordRepository).deleteAgonyRecord(any(), any(), any(), any());
     }
 
     @Test
@@ -107,8 +107,8 @@ class AgonyRecordServiceTest {
             .recordContent("수정 내용")
             .build();
 
-        agonyRecordService.reviseAgonyRecord(1L, 1L, 1L, reviseAgonyRecordRequest);
+        agonyRecordService.reviseAgonyRecord(1L, 1L, 1L, 1L, reviseAgonyRecordRequest);
 
-        verify(agonyRecordRepository).reviseAgonyRecord(any(), any(), any(), any(), any());
+        verify(agonyRecordRepository).reviseAgonyRecord(any(), any(), any(), any(), any(), any());
     }
 }

--- a/src/test/java/toy/bookchat/bookchat/domain/bookreport/api/BookReportControllerTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/bookreport/api/BookReportControllerTest.java
@@ -53,7 +53,7 @@ class BookReportControllerTest extends ControllerTestExtension {
             .content("요런 요런 내용, 저런저런 내용을 많이 배움")
             .build();
 
-        mockMvc.perform(post("/v1/api/books/{bookId}/report", 1L)
+        mockMvc.perform(post("/v1/api/bookshelves/{bookShelfId}/report", 1L)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .contentType(APPLICATION_JSON)
@@ -64,7 +64,7 @@ class BookReportControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
-                    parameterWithName("bookId").description("Book Id")
+                    parameterWithName("bookShelfId").description("BookShelf Id")
                 ),
                 requestFields(
                     fieldWithPath("title").type(STRING).description("독후감 제목"),
@@ -84,7 +84,7 @@ class BookReportControllerTest extends ControllerTestExtension {
         bookReport.setCreatedAt(LocalDateTime.now());
         BookReportResponse bookReportResponse = BookReportResponse.from(bookReport);
         when(bookReportService.getBookReportResponse(any(), any())).thenReturn(bookReportResponse);
-        mockMvc.perform(get("/v1/api/books/{bookId}/report", 1L)
+        mockMvc.perform(get("/v1/api/bookshelves/{bookShelfId}/report", 1L)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal())))
             .andExpect(status().isOk())
@@ -93,7 +93,7 @@ class BookReportControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
-                    parameterWithName("bookId").description("Book Id")
+                    parameterWithName("bookShelfId").description("BookShelf Id")
                 ),
                 responseFields(
                     fieldWithPath("reportTitle").type(STRING).description("독후감 제목"),
@@ -104,7 +104,7 @@ class BookReportControllerTest extends ControllerTestExtension {
 
     @Test
     void 독후감_삭제_성공() throws Exception {
-        mockMvc.perform(delete("/v1/api/books/{bookId}/report", 1L)
+        mockMvc.perform(delete("/v1/api/bookshelves/{bookShelfId}/report", 1L)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal())))
             .andExpect(status().isOk())
@@ -113,7 +113,7 @@ class BookReportControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
-                    parameterWithName("bookId").description("Book Id")
+                    parameterWithName("bookShelfId").description("BookShelf Id")
                 )));
 
         verify(bookReportService).deleteBookReport(any(), any());
@@ -127,7 +127,7 @@ class BookReportControllerTest extends ControllerTestExtension {
                 "내용은 바꿀수도 아닐수도 있기 때문에 이전 상태 값을 완전히 가지고있기 때문에 똑같이 보내주거나 바꿔서 보내주세요 put으로 멱등성을 보장해줍시다.")
             .build();
 
-        mockMvc.perform(put("/v1/api/books/{bookId}/report", 1L)
+        mockMvc.perform(put("/v1/api/bookshelves/{bookShelfId}/report", 1L)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .contentType(APPLICATION_JSON)
@@ -138,7 +138,7 @@ class BookReportControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
-                    parameterWithName("bookId").description("Book Id")
+                    parameterWithName("bookShelfId").description("BookShelf Id")
                 ),
                 requestFields(
                     fieldWithPath("title").type(STRING).description("독후감 제목"),

--- a/src/test/java/toy/bookchat/bookchat/domain/bookreport/service/BookReportServiceTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/bookreport/service/BookReportServiceTest.java
@@ -58,7 +58,7 @@ class BookReportServiceTest {
         BookShelf bookShelf = mock(BookShelf.class);
 
         when(user.getId()).thenReturn(1L);
-        when(bookShelfRepository.findByUserIdAndBookId(any(), any())).thenReturn(
+        when(bookShelfRepository.findByIdAndUserId(any(), any())).thenReturn(
             Optional.of(bookShelf));
 
         bookReportService.writeReport(writeBookReportRequest, 1L, user.getId());
@@ -76,7 +76,7 @@ class BookReportServiceTest {
             .build();
 
         when(user.getId()).thenReturn(1L);
-        when(bookShelfRepository.findByUserIdAndBookId(any(), any())).thenReturn(
+        when(bookShelfRepository.findByIdAndUserId(any(), any())).thenReturn(
             Optional.of(bookShelf));
 
         bookReportService.writeReport(writeBookReportRequest, 1L, user.getId());
@@ -99,7 +99,7 @@ class BookReportServiceTest {
         BookShelf bookShelf = BookShelf.builder()
             .build();
 
-        when(bookShelfRepository.findByUserIdAndBookId(any(), any())).thenReturn(
+        when(bookShelfRepository.findByIdAndUserId(any(), any())).thenReturn(
             Optional.of(bookShelf));
 
         assertThatThrownBy(() -> {
@@ -117,7 +117,7 @@ class BookReportServiceTest {
             .bookReport(bookReport)
             .build();
 
-        when(bookShelfRepository.findByUserIdAndBookId(any(), any())).thenReturn(
+        when(bookShelfRepository.findByIdAndUserId(any(), any())).thenReturn(
             Optional.of(bookShelf));
         BookReportResponse bookReportResponse = bookReportService.getBookReportResponse(1L, 1L);
 
@@ -135,7 +135,7 @@ class BookReportServiceTest {
             .bookReport(bookReport)
             .build();
 
-        when(bookShelfRepository.findByUserIdAndBookId(any(), any())).thenReturn(
+        when(bookShelfRepository.findByIdAndUserId(any(), any())).thenReturn(
             Optional.of(bookShelf));
 
         bookReportService.deleteBookReport(1L, 1L);
@@ -158,7 +158,7 @@ class BookReportServiceTest {
             .bookReport(bookReport)
             .build();
 
-        when(bookShelfRepository.findByUserIdAndBookId(any(), any())).thenReturn(
+        when(bookShelfRepository.findByIdAndUserId(any(), any())).thenReturn(
             Optional.of(bookShelf));
 
         bookReportService.reviseBookReport(1L, 1L, reviseBookReportRequest);

--- a/src/test/java/toy/bookchat/bookchat/domain/bookreport/service/BookReportServiceTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/bookreport/service/BookReportServiceTest.java
@@ -158,7 +158,7 @@ class BookReportServiceTest {
             .bookReport(bookReport)
             .build();
 
-        when(bookShelfRepository.findByIdAndUserId(any(), any())).thenReturn(
+        when(bookShelfRepository.findWithReportByIdAndUserId(any(), any())).thenReturn(
             Optional.of(bookShelf));
 
         bookReportService.reviseBookReport(1L, 1L, reviseBookReportRequest);

--- a/src/test/java/toy/bookchat/bookchat/domain/bookshelf/api/BookShelfControllerTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/bookshelf/api/BookShelfControllerTest.java
@@ -94,7 +94,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
 
     @Test
     void 로그인하지_않은_사용자_요청_401() throws Exception {
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .content(objectMapper.writeValueAsString(getBookShelfRequest(READING)))
                 .contentType(APPLICATION_JSON))
             .andExpect(status().isUnauthorized());
@@ -102,7 +102,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
 
     @Test
     void 읽고_있는_책_등록_성공() throws Exception {
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .content(objectMapper.writeValueAsString(getBookShelfRequest(READING)))
                 .contentType(APPLICATION_JSON)
@@ -126,7 +126,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
 
     @Test
     void 읽은_책_등록_성공() throws Exception {
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .content(
                     objectMapper.writeValueAsString(getBookShelfRequest(COMPLETE)))
@@ -153,7 +153,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
 
     @Test
     void 읽을_책_등록_성공() throws Exception {
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .content(objectMapper.writeValueAsString(getBookShelfRequest(WISH)))
                 .contentType(APPLICATION_JSON)
@@ -179,7 +179,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
 
     @Test
     void null로_요청_실패() throws Exception {
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .contentType(APPLICATION_JSON)
                 .with(user(getUserPrincipal())))
@@ -192,7 +192,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .bookRequest(getBookRequest())
             .build();
 
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .content(objectMapper.writeValueAsString(bookShelfRequest))
                 .contentType(APPLICATION_JSON)
@@ -214,7 +214,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .readingStatus(WISH)
             .build();
 
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .content(objectMapper.writeValueAsString(bookShelfRequest))
                 .contentType(APPLICATION_JSON)
@@ -236,7 +236,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .readingStatus(WISH)
             .build();
 
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .content(objectMapper.writeValueAsString(bookShelfRequest))
                 .contentType(APPLICATION_JSON)
@@ -257,7 +257,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .readingStatus(WISH)
             .build();
 
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .content(objectMapper.writeValueAsString(bookShelfRequest))
                 .contentType(APPLICATION_JSON)
@@ -280,7 +280,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .readingStatus(WISH)
             .build();
 
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .content(objectMapper.writeValueAsString(bookShelfRequest))
                 .contentType(APPLICATION_JSON)
@@ -302,7 +302,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .readingStatus(WISH)
             .build();
 
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .content(objectMapper.writeValueAsString(bookShelfRequest))
                 .contentType(APPLICATION_JSON)
@@ -325,7 +325,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .readingStatus(WISH)
             .build();
 
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .content(objectMapper.writeValueAsString(bookShelfRequest))
                 .contentType(APPLICATION_JSON)
@@ -347,7 +347,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .readingStatus(WISH)
             .build();
 
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .content(objectMapper.writeValueAsString(bookShelfRequest))
                 .contentType(APPLICATION_JSON)
@@ -370,7 +370,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .readingStatus(WISH)
             .build();
 
-        mockMvc.perform(post("/v1/api/bookshelf/books")
+        mockMvc.perform(post("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .content(objectMapper.writeValueAsString(bookShelfRequest))
                 .contentType(APPLICATION_JSON)
@@ -394,6 +394,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .build();
 
         BookShelf bookShelf = BookShelf.builder()
+            .id(1L)
             .book(book)
             .user(user)
             .pages(152)
@@ -407,10 +408,11 @@ class BookShelfControllerTest extends ControllerTestExtension {
         SearchBookShelfByReadingStatus searchBookShelfByReadingStatus = new SearchBookShelfByReadingStatus(
             bookShelves);
 
-        when(bookShelfService.takeBooksOutOfBookShelf(any(ReadingStatus.class), any(Pageable.class),
+        when(bookShelfService.takeBooksOutOfBookShelves(any(ReadingStatus.class),
+            any(Pageable.class),
             any())).thenReturn(searchBookShelfByReadingStatus);
 
-        mockMvc.perform(get("/v1/api/bookshelf/books")
+        mockMvc.perform(get("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .queryParam("readingStatus", "READING")
                 .queryParam("size", "5")
@@ -430,6 +432,8 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     parameterWithName("sort").description("등록순-id | 변경순-updatedAt")
                 ),
                 responseFields(
+                    fieldWithPath("contents[].bookShelfId").type(NUMBER)
+                        .description("BookShelf Id"),
                     fieldWithPath("contents[].bookId").type(NUMBER).description("Book Id"),
                     fieldWithPath("contents[].title").type(STRING).description("제목"),
                     fieldWithPath("contents[].isbn").type(STRING).description("ISBN"),
@@ -443,7 +447,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     .and(getPageField()))
             );
 
-        verify(bookShelfService).takeBooksOutOfBookShelf(any(ReadingStatus.class),
+        verify(bookShelfService).takeBooksOutOfBookShelves(any(ReadingStatus.class),
             any(Pageable.class), any());
     }
 
@@ -464,6 +468,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .build();
 
         BookShelf bookShelf = BookShelf.builder()
+            .id(1L)
             .book(book)
             .user(user)
             .pages(0)
@@ -478,10 +483,11 @@ class BookShelfControllerTest extends ControllerTestExtension {
         SearchBookShelfByReadingStatus searchBookShelfByReadingStatus = new SearchBookShelfByReadingStatus(
             bookShelves);
 
-        when(bookShelfService.takeBooksOutOfBookShelf(any(ReadingStatus.class), any(Pageable.class),
+        when(bookShelfService.takeBooksOutOfBookShelves(any(ReadingStatus.class),
+            any(Pageable.class),
             any())).thenReturn(searchBookShelfByReadingStatus);
 
-        mockMvc.perform(get("/v1/api/bookshelf/books")
+        mockMvc.perform(get("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .queryParam("readingStatus", "COMPLETE")
                 .queryParam("size", "5")
@@ -501,6 +507,8 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     parameterWithName("sort").description("등록순-id | 변경순-updatedAt")
                 ),
                 responseFields(
+                    fieldWithPath("contents[].bookShelfId").type(NUMBER)
+                        .description("BookShelf Id"),
                     fieldWithPath("contents[].bookId").type(NUMBER).description("Book Id"),
                     fieldWithPath("contents[].title").type(STRING).description("제목"),
                     fieldWithPath("contents[].isbn").type(STRING).description("ISBN"),
@@ -514,7 +522,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     .and(getPageField()))
             );
 
-        verify(bookShelfService).takeBooksOutOfBookShelf(any(ReadingStatus.class),
+        verify(bookShelfService).takeBooksOutOfBookShelves(any(ReadingStatus.class),
             any(Pageable.class), any());
     }
 
@@ -534,6 +542,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .build();
 
         BookShelf bookShelf = BookShelf.builder()
+            .id(1L)
             .book(book)
             .user(user)
             .pages(0)
@@ -548,10 +557,11 @@ class BookShelfControllerTest extends ControllerTestExtension {
         SearchBookShelfByReadingStatus searchBookShelfByReadingStatus = new SearchBookShelfByReadingStatus(
             bookShelves);
 
-        when(bookShelfService.takeBooksOutOfBookShelf(any(ReadingStatus.class), any(Pageable.class),
+        when(bookShelfService.takeBooksOutOfBookShelves(any(ReadingStatus.class),
+            any(Pageable.class),
             any())).thenReturn(searchBookShelfByReadingStatus);
 
-        mockMvc.perform(get("/v1/api/bookshelf/books")
+        mockMvc.perform(get("/v1/api/bookshelves")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .queryParam("readingStatus", "WISH")
                 .queryParam("size", "5")
@@ -571,6 +581,8 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     parameterWithName("sort").description("등록순-id | 변경순-updatedAt")
                 ),
                 responseFields(
+                    fieldWithPath("contents[].bookShelfId").type(NUMBER)
+                        .description("BookShelf Id"),
                     fieldWithPath("contents[].bookId").type(NUMBER).description("Book Id"),
                     fieldWithPath("contents[].title").type(STRING).description("제목"),
                     fieldWithPath("contents[].isbn").type(STRING).description("ISBN"),
@@ -584,7 +596,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     .and(getPageField()))
             );
 
-        verify(bookShelfService).takeBooksOutOfBookShelf(any(ReadingStatus.class),
+        verify(bookShelfService).takeBooksOutOfBookShelves(any(ReadingStatus.class),
             any(Pageable.class), any());
     }
 
@@ -596,7 +608,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .readingStatus(READING)
             .build();
 
-        mockMvc.perform(put("/v1/api/bookshelf/books/{bookId}", 1L)
+        mockMvc.perform(put("/v1/api/bookshelves/{bookShelfId}", 1L)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .contentType(APPLICATION_JSON)
@@ -607,7 +619,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
-                    parameterWithName("bookId").description("Book Id")
+                    parameterWithName("bookShelfId").description("BookShelf Id")
                 ),
                 requestFields(
                     fieldWithPath("pages").type(NUMBER).optional().description("현재 읽고 있는 페이지 번호"),
@@ -620,7 +632,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
 
     @Test
     void 서재에_넣어둔_책_삭제_성공() throws Exception {
-        mockMvc.perform(delete("/v1/api/bookshelf/books/{bookId}", 1)
+        mockMvc.perform(delete("/v1/api/bookshelves/{bookShelfId}", 1)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal())))
             .andExpect(status().isOk())
@@ -629,11 +641,11 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
-                    parameterWithName("bookId").description("Book Id")
+                    parameterWithName("bookShelfId").description("BookShelf Id")
                 )
             ));
 
-        verify(bookShelfService).deleteBookOnBookShelf(any(), any());
+        verify(bookShelfService).deleteBookShelf(any(), any());
     }
 
     @Test
@@ -644,7 +656,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .readingStatus(READING)
             .build();
 
-        mockMvc.perform(put("/v1/api/bookshelf/books/{bookId}", 1)
+        mockMvc.perform(put("/v1/api/bookshelves/{bookShelfId}", 1)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .contentType(APPLICATION_JSON)
@@ -655,7 +667,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
-                    parameterWithName("bookId").description("Book Id")
+                    parameterWithName("bookShelfId").description("BookShelf Id")
                 ),
                 requestFields(
                     fieldWithPath("pages").type(NUMBER).optional().description("현재 읽고 있는 페이지 번호"),
@@ -674,7 +686,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .readingStatus(COMPLETE)
             .build();
 
-        mockMvc.perform(put("/v1/api/bookshelf/books/{bookId}", 1L)
+        mockMvc.perform(put("/v1/api/bookshelves/{bookShelfId}", 1L)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .contentType(APPLICATION_JSON)
@@ -685,7 +697,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
-                    parameterWithName("bookId").description("Book Id")
+                    parameterWithName("bookShelfId").description("BookShelf Id")
                 ),
                 requestFields(
                     fieldWithPath("pages").optional().description("현재 읽고 있는 페이지 번호"),
@@ -704,7 +716,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
             .readingStatus(COMPLETE)
             .build();
 
-        mockMvc.perform(put("/v1/api/bookshelf/books/{bookId}", 1L)
+        mockMvc.perform(put("/v1/api/bookshelves/{bookShelfId}", 1L)
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .with(user(getUserPrincipal()))
                 .contentType(APPLICATION_JSON)
@@ -715,7 +727,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     headerWithName(AUTHORIZATION).description("Bearer [JWT token]")
                 ),
                 pathParameters(
-                    parameterWithName("bookId").description("Book Id")
+                    parameterWithName("bookShelfId").description("BookShelf Id")
                 ),
                 requestFields(
                     fieldWithPath("pages").optional().description("현재 읽고 있는 페이지 번호"),
@@ -736,7 +748,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
 
         when(bookShelfService.getBookIfExisted(any(), any(), any())).thenReturn(
             existenceBookOnBookShelfResponse);
-        mockMvc.perform(get("/v1/api/bookshelf/books/existence")
+        mockMvc.perform(get("/v1/api/bookshelves/book")
                 .header(AUTHORIZATION, JWT_TOKEN)
                 .param("isbn", "1234567891011 0123456789")
                 .param("publishAt", LocalDate.now().toString()))

--- a/src/test/java/toy/bookchat/bookchat/domain/bookshelf/api/BookShelfControllerTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/bookshelf/api/BookShelfControllerTest.java
@@ -427,7 +427,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     parameterWithName("readingStatus").description("READING"),
                     parameterWithName("size").description("page 당 size"),
                     parameterWithName("page").description("한번에 조회할 page수"),
-                    parameterWithName("sort").description("등록순-id")
+                    parameterWithName("sort").description("등록순-id | 변경순-updatedAt")
                 ),
                 responseFields(
                     fieldWithPath("contents[].bookId").type(NUMBER).description("Book Id"),
@@ -498,7 +498,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     parameterWithName("readingStatus").description("COMPLETE"),
                     parameterWithName("size").description("page 당 size"),
                     parameterWithName("page").description("한번에 조회할 page수"),
-                    parameterWithName("sort").description("등록순-id")
+                    parameterWithName("sort").description("등록순-id | 변경순-updatedAt")
                 ),
                 responseFields(
                     fieldWithPath("contents[].bookId").type(NUMBER).description("Book Id"),
@@ -568,7 +568,7 @@ class BookShelfControllerTest extends ControllerTestExtension {
                     parameterWithName("readingStatus").description("WISH"),
                     parameterWithName("size").description("page 당 size"),
                     parameterWithName("page").description("한번에 조회할 page수"),
-                    parameterWithName("sort").description("등록순-id")
+                    parameterWithName("sort").description("등록순-id | 변경순-updatedAt")
                 ),
                 responseFields(
                     fieldWithPath("contents[].bookId").type(NUMBER).description("Book Id"),

--- a/src/test/java/toy/bookchat/bookchat/domain/bookshelf/api/BookShelfControllerTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/bookshelf/api/BookShelfControllerTest.java
@@ -434,7 +434,6 @@ class BookShelfControllerTest extends ControllerTestExtension {
                 responseFields(
                     fieldWithPath("contents[].bookShelfId").type(NUMBER)
                         .description("BookShelf Id"),
-                    fieldWithPath("contents[].bookId").type(NUMBER).description("Book Id"),
                     fieldWithPath("contents[].title").type(STRING).description("제목"),
                     fieldWithPath("contents[].isbn").type(STRING).description("ISBN"),
                     fieldWithPath("contents[].bookCoverImageUrl").type(STRING).optional()
@@ -509,7 +508,6 @@ class BookShelfControllerTest extends ControllerTestExtension {
                 responseFields(
                     fieldWithPath("contents[].bookShelfId").type(NUMBER)
                         .description("BookShelf Id"),
-                    fieldWithPath("contents[].bookId").type(NUMBER).description("Book Id"),
                     fieldWithPath("contents[].title").type(STRING).description("제목"),
                     fieldWithPath("contents[].isbn").type(STRING).description("ISBN"),
                     fieldWithPath("contents[].bookCoverImageUrl").type(STRING).optional()
@@ -583,7 +581,6 @@ class BookShelfControllerTest extends ControllerTestExtension {
                 responseFields(
                     fieldWithPath("contents[].bookShelfId").type(NUMBER)
                         .description("BookShelf Id"),
-                    fieldWithPath("contents[].bookId").type(NUMBER).description("Book Id"),
                     fieldWithPath("contents[].title").type(STRING).description("제목"),
                     fieldWithPath("contents[].isbn").type(STRING).description("ISBN"),
                     fieldWithPath("contents[].bookCoverImageUrl").type(STRING).optional()
@@ -742,7 +739,6 @@ class BookShelfControllerTest extends ControllerTestExtension {
     void isbn과_출판일자로_서재에_책이_등록되었는지_조회_성공() throws Exception {
         ExistenceBookOnBookShelfResponse existenceBookOnBookShelfResponse = ExistenceBookOnBookShelfResponse.builder()
             .bookShelfId(1L)
-            .bookId(1L)
             .readingStatus(WISH)
             .build();
 
@@ -763,7 +759,6 @@ class BookShelfControllerTest extends ControllerTestExtension {
                 ),
                 responseFields(
                     fieldWithPath("bookShelfId").type(NUMBER).description("책이 등록된 서재 ID"),
-                    fieldWithPath("bookId").type(NUMBER).description("책 ID"),
                     fieldWithPath("readingStatus").type(STRING).description("서재에 등록된 책의 현재 상태")
                 )));
 

--- a/src/test/java/toy/bookchat/bookchat/domain/bookshelf/repository/BookShelfRepositoryTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/bookshelf/repository/BookShelfRepositoryTest.java
@@ -196,7 +196,7 @@ class BookShelfRepositoryTest {
 
         bookShelfRepository.save(bookShelf);
 
-        bookShelfRepository.deleteBookByUserIdAndBookId(user.getId(), book.getId());
+        bookShelfRepository.deleteBookShelfByIdAndUserId(bookShelf.getId(), user.getId());
 
         int result = bookShelfRepository.findAll().size();
         assertThat(result).isZero();
@@ -224,29 +224,7 @@ class BookShelfRepositoryTest {
         assertThat(findBookShelf).isEqualTo(bookShelf);
 
     }
-
-    @Test
-    void user_id_book_id로_서재_조회성공() throws Exception {
-        Book book = getBook("1-4133-0454-0");
-
-        bookRepository.save(book);
-
-        User user = User.builder().name("hi").build();
-        userRepository.save(user);
-
-        BookShelf bookShelf = BookShelf.builder()
-            .book(book)
-            .user(user)
-            .readingStatus(ReadingStatus.READING)
-            .build();
-
-        bookShelfRepository.save(bookShelf);
-
-        BookShelf findBookShelf = bookShelfRepository.findByUserIdAndBookId(
-            user.getId(), book.getId()).get();
-        assertThat(findBookShelf).isEqualTo(bookShelf);
-    }
-
+    
     @Test
     void 사용자가_생성한_책장_전부_삭제성공() throws Exception {
         Book book1 = getBook("1-4133-0454-0");

--- a/src/test/java/toy/bookchat/bookchat/domain/bookshelf/repository/BookShelfRepositoryTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/bookshelf/repository/BookShelfRepositoryTest.java
@@ -203,6 +203,29 @@ class BookShelfRepositoryTest {
     }
 
     @Test
+    void bookShelfId_userId로_서재_조회_성공() throws Exception {
+        Book book = getBook("1-4133-0454-0");
+
+        bookRepository.save(book);
+
+        User user = User.builder().name("hi").build();
+        userRepository.save(user);
+
+        BookShelf bookShelf = BookShelf.builder()
+            .book(book)
+            .user(user)
+            .readingStatus(ReadingStatus.READING)
+            .build();
+
+        bookShelfRepository.save(bookShelf);
+
+        BookShelf findBookShelf = bookShelfRepository.findByIdAndUserId(bookShelf.getId(),
+            user.getId()).get();
+        assertThat(findBookShelf).isEqualTo(bookShelf);
+
+    }
+
+    @Test
     void user_id_book_id로_서재_조회성공() throws Exception {
         Book book = getBook("1-4133-0454-0");
 

--- a/src/test/java/toy/bookchat/bookchat/domain/bookshelf/repository/BookShelfRepositoryTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/bookshelf/repository/BookShelfRepositoryTest.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Sort;
 import toy.bookchat.bookchat.domain.RepositoryTest;
 import toy.bookchat.bookchat.domain.book.Book;
 import toy.bookchat.bookchat.domain.book.repository.BookRepository;
+import toy.bookchat.bookchat.domain.bookreport.BookReport;
+import toy.bookchat.bookchat.domain.bookreport.repository.BookReportRepository;
 import toy.bookchat.bookchat.domain.bookshelf.BookShelf;
 import toy.bookchat.bookchat.domain.bookshelf.ReadingStatus;
 import toy.bookchat.bookchat.domain.bookshelf.Star;
@@ -24,6 +26,8 @@ class BookShelfRepositoryTest {
 
     @Autowired
     private BookRepository bookRepository;
+    @Autowired
+    private BookReportRepository bookReportRepository;
     @Autowired
     private UserRepository userRepository;
     @Autowired
@@ -224,7 +228,35 @@ class BookShelfRepositoryTest {
         assertThat(findBookShelf).isEqualTo(bookShelf);
 
     }
-    
+
+    @Test
+    void bookShelfId_userId로_서재_독후감_조회_성공() throws Exception {
+        Book book = getBook("1-4133-0454-0");
+        bookRepository.save(book);
+
+        User user = User.builder().name("hi").build();
+        userRepository.save(user);
+
+        BookReport bookReport = BookReport.builder()
+            .title("test report")
+            .content("test report content")
+            .build();
+        bookReportRepository.save(bookReport);
+
+        BookShelf bookShelf = BookShelf.builder()
+            .book(book)
+            .user(user)
+            .bookReport(bookReport)
+            .readingStatus(ReadingStatus.READING)
+            .build();
+        bookShelfRepository.save(bookShelf);
+
+        BookShelf findBookShelf = bookShelfRepository.findWithReportByIdAndUserId(bookShelf.getId(),
+            user.getId()).get();
+
+        assertThat(findBookShelf.getBookReport().getTitle()).isEqualTo(bookReport.getTitle());
+    }
+
     @Test
     void 사용자가_생성한_책장_전부_삭제성공() throws Exception {
         Book book1 = getBook("1-4133-0454-0");

--- a/src/test/java/toy/bookchat/bookchat/domain/bookshelf/service/BookShelfServiceTest.java
+++ b/src/test/java/toy/bookchat/bookchat/domain/bookshelf/service/BookShelfServiceTest.java
@@ -171,7 +171,7 @@ class BookShelfServiceTest {
 
         when(bookShelfRepository.findSpecificStatusBookByUserId(any(), any(), any())).thenReturn(
             bookShelves);
-        SearchBookShelfByReadingStatus searchBookShelfByReadingStatus = bookShelfService.takeBooksOutOfBookShelf(
+        SearchBookShelfByReadingStatus searchBookShelfByReadingStatus = bookShelfService.takeBooksOutOfBookShelves(
             READING, pageable, 1L);
 
         verify(bookShelfRepository).findSpecificStatusBookByUserId(READING, pageable, 1L);
@@ -205,7 +205,7 @@ class BookShelfServiceTest {
         when(bookShelfRepository.findSpecificStatusBookByUserId(any(), any(), any())).thenReturn(
             bookShelves);
 
-        SearchBookShelfByReadingStatus searchBookShelfByReadingStatus = bookShelfService.takeBooksOutOfBookShelf(
+        SearchBookShelfByReadingStatus searchBookShelfByReadingStatus = bookShelfService.takeBooksOutOfBookShelves(
             COMPLETE, pageable, user.getId());
 
         verify(bookShelfRepository).findSpecificStatusBookByUserId(COMPLETE, pageable,
@@ -238,7 +238,7 @@ class BookShelfServiceTest {
         when(bookShelfRepository.findSpecificStatusBookByUserId(any(), any(), any())).thenReturn(
             bookShelves);
 
-        SearchBookShelfByReadingStatus searchBookShelfByReadingStatus = bookShelfService.takeBooksOutOfBookShelf(
+        SearchBookShelfByReadingStatus searchBookShelfByReadingStatus = bookShelfService.takeBooksOutOfBookShelves(
             WISH, pageable, user.getId());
 
         verify(bookShelfRepository).findSpecificStatusBookByUserId(WISH, pageable, user.getId());
@@ -261,7 +261,7 @@ class BookShelfServiceTest {
             .star(null)
             .build();
 
-        when(bookShelfRepository.findByUserIdAndBookId(any(), any())).thenReturn(
+        when(bookShelfRepository.findByIdAndUserId(any(), any())).thenReturn(
             Optional.of(bookShelf));
 
         bookShelfService.reviseBookShelf(1L, reviseBookShelfRequest, 1L);
@@ -272,9 +272,9 @@ class BookShelfServiceTest {
 
     @Test
     void 책장에서_책_삭제_성공() throws Exception {
-        bookShelfService.deleteBookOnBookShelf(1L, 1L);
+        bookShelfService.deleteBookShelf(1L, 1L);
 
-        verify(bookShelfRepository).deleteBookByUserIdAndBookId(any(), any());
+        verify(bookShelfRepository).deleteBookShelfByIdAndUserId(any(), any());
     }
 
     @Test
@@ -289,7 +289,7 @@ class BookShelfServiceTest {
             .readingStatus(WISH)
             .build();
 
-        when(bookShelfRepository.findByUserIdAndBookId(any(), any())).thenReturn(
+        when(bookShelfRepository.findByIdAndUserId(any(), any())).thenReturn(
             Optional.of(bookShelf));
 
         bookShelfService.reviseBookShelf(1L, reviseBookShelfRequest, 1L);
@@ -318,7 +318,7 @@ class BookShelfServiceTest {
             .readingStatus(COMPLETE)
             .build();
 
-        when(bookShelfRepository.findByUserIdAndBookId(any(), any())).thenReturn(
+        when(bookShelfRepository.findByIdAndUserId(any(), any())).thenReturn(
             Optional.of(bookShelf));
         bookShelfService.reviseBookShelf(1L, reviseBookShelfRequest, 1L);
 


### PR DESCRIPTION
- [x] 고민폴더 책별로 구분되도록 수정
- [x] 고민 폴더 삭제 동작 오류 수정
- [x] 고민기록 조회 API 오류 수정
- [x] 서재 조회시 updated_at정렬 조건 동작 테스트 (정상 동작 확인)
- [x] 서재,고민,고민기록,독후감 api endpoint 수정 (대부분 bookshelf -> bookshelves 복수형으로 변경)
- [x] bookid parameter 삭제 bookshelfid를 사용하는 방식으로 모두 변경(문서 반영)